### PR TITLE
fix: avoid focus raise after override space switch

### DIFF
--- a/DesktopRenamer/Services/Space/SpaceHelper.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper.swift
@@ -37,6 +37,7 @@ class SpaceHelper {
     private static var isSwitching = false
     static var lastProgrammaticSwitchTime: TimeInterval = 0
     static var lastProgrammaticTargetSpaceID: String? = nil
+    static var lastProgrammaticSwitchUsedSLS = false
     
     // Session state for active dragging operations.
     private static var originalMousePoint: CGPoint? = nil
@@ -231,6 +232,7 @@ class SpaceHelper {
         DiagnosticEventLog.shared.record(subsystem: "SpaceHelper", level: "info", "switchToSpace(\(spaceID), forceInstant=\(forceInstant))")
         lastProgrammaticSwitchTime = Date().timeIntervalSince1970
         lastProgrammaticTargetSpaceID = spaceID
+        lastProgrammaticSwitchUsedSLS = false
 
         if !forceInstant {
             guard !isSwitching else { return }
@@ -466,6 +468,7 @@ class SpaceHelper {
                 if initializedBridge.responds(to: performSel) {
                     DiagnosticEventLog.shared.record(subsystem: "SpaceHelper", level: "info", "Executing SLS operation via SLSWindowManagementFallbackBridge: \(displayUUID), \(spaceID)")
                     initializedBridge.perform(performSel, with: initializedOp)
+                    lastProgrammaticSwitchUsedSLS = true
                     return true
                 }
             }
@@ -475,12 +478,14 @@ class SpaceHelper {
         if let operation = initializedOp as? Operation {
             DiagnosticEventLog.shared.record(subsystem: "SpaceHelper", level: "info", "Executing SLS operation via OperationQueue: \(displayUUID), \(spaceID)")
             OperationQueue.main.addOperation(operation)
+            lastProgrammaticSwitchUsedSLS = true
             return true
         } else {
             let startSel = NSSelectorFromString("start")
             if initializedOp.responds(to: startSel) {
                 DiagnosticEventLog.shared.record(subsystem: "SpaceHelper", level: "info", "Starting SLS operation via start selector: \(displayUUID), \(spaceID)")
                 initializedOp.perform(startSel)
+                lastProgrammaticSwitchUsedSLS = true
                 return true
             }
         }

--- a/DesktopRenamer/Services/Space/SpaceManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager.swift
@@ -424,11 +424,12 @@ class SpaceManager: ObservableObject {
                 self.pruneStaleMovedWindows()
                 shouldUpdateWidget = true
 
-                // If it was a programmatic space switch on macOS 27+, restore focus
-                // now that the space change is complete. On older macOS the native gesture
-                // path handles focus correctly on its own.
+                // If it was an SLS programmatic space switch, restore focus now
+                // that the space change is complete. Native dock-swipe events
+                // preserve focus on their own; raising a guessed top window here
+                // can reorder the target space unexpectedly.
                 let now = Date().timeIntervalSince1970
-                let isProgrammatic = SpaceHelper.shouldSwitchToSpaceUsingSLS() &&
+                let isProgrammatic = SpaceHelper.lastProgrammaticSwitchUsedSLS &&
                                      (now - SpaceHelper.lastProgrammaticSwitchTime < 2.0) &&
                                      (targetUUID == SpaceHelper.lastProgrammaticTargetSpaceID)
                 if isProgrammatic {


### PR DESCRIPTION
Remove redundant focus window preservation since macOS already handles it.