### PR TITLE
feat: standardize SpaceAPI

### DIFF
--- a/DesktopRenamer/DesktopRenamer.sdef
+++ b/DesktopRenamer/DesktopRenamer.sdef
@@ -21,9 +21,9 @@
             <property name="display name" code="DsNm" type="text"><cocoa key="displayName"/></property>
             <property name="number" code="SpNo" type="integer"><cocoa key="number"/></property>
             <property name="full screen" code="Fscr" type="boolean"><cocoa key="isFullscreen"/></property>
-            <property name="app name" code="ApNm" type="text"><cocoa key="appName"/></property>
-            <property name="app path" code="ApPt" type="text"><cocoa key="appPath"/></property>
-            <property name="global shortcut number" code="GsNo" type="integer"><cocoa key="globalShortcutNumber"/></property>
+            <property name="app name" code="ApNm" type="text" description="Full-screen app name when available"><cocoa key="appName"/></property>
+            <property name="app path" code="ApPt" type="text" description="Full-screen app path when available"><cocoa key="appPath"/></property>
+            <property name="global shortcut number" code="GsNo" type="integer" description="Configured shortcut number when available"><cocoa key="globalShortcutNumber"/></property>
         </record-type>
 
         <record-type name="space snapshot" code="DkSn" description="A versioned snapshot of Mission Control spaces">
@@ -39,8 +39,8 @@
             <property name="id" code="WiID" type="integer"><cocoa key="id"/></property>
             <property name="process ID" code="PrID" type="integer"><cocoa key="pid"/></property>
             <property name="owner name" code="OwNm" type="text"><cocoa key="ownerName"/></property>
-            <property name="app path" code="WiPt" type="text"><cocoa key="appPath"/></property>
-            <property name="title" code="WiTl" type="text"><cocoa key="title"/></property>
+            <property name="app path" code="WiPt" type="text" description="Application path when available"><cocoa key="appPath"/></property>
+            <property name="title" code="WiTl" type="text" description="Window title when available"><cocoa key="title"/></property>
             <property name="space ID" code="WiSp" type="text"><cocoa key="spaceID"/></property>
             <property name="minimized" code="MiWd" type="boolean"><cocoa key="isMinimized"/></property>
             <property name="hidden" code="HiWd" type="boolean"><cocoa key="isHidden"/></property>
@@ -119,9 +119,9 @@
             <result type="text" description="The semantic version of the external API contract"/>
         </command>
         
-        <command name="get all spaces" code="DskRGAll" description="Get a list of all spaces in format 'ID~Name~DisplayID~Num'">
+        <command name="get all spaces" code="DskRGAll" description="Get a list of all spaces in the legacy delimiter format">
             <cocoa class="DesktopRenamer.GetAllSpacesCommand"/>
-            <result type="text" description="List of spaces separated by newlines, format: ID~Name~DisplayID~Num"/>
+            <result type="text" description="List of spaces separated by newlines, format: ID~Name~DisplayName~Num~IsFullscreen~AppPath"/>
         </command>
         
         <command name="rename space" code="DskRRnSp" description="Rename a specific space by ID">

--- a/DesktopRenamer/DesktopRenamer.sdef
+++ b/DesktopRenamer/DesktopRenamer.sdef
@@ -8,7 +8,9 @@
             <property name="JSON-RPC version" code="JRpc" type="text"><cocoa key="jsonRPCVersion"/></property>
             <property name="supported methods" code="SMet" type="list of text"><cocoa key="supportedMethods"/></property>
             <property name="legacy notifications" code="LNot" type="boolean"><cocoa key="legacyNotifications"/></property>
+            <property name="legacy compatibility" code="LCom" type="text"><cocoa key="legacyCompatibility"/></property>
             <property name="event notifications" code="ENot" type="boolean"><cocoa key="eventNotifications"/></property>
+            <property name="event capabilities" code="ECap" type="list of text"><cocoa key="eventCapabilities"/></property>
             <property name="maximum payload bytes" code="MPBy" type="integer"><cocoa key="maxPayloadBytes"/></property>
         </record-type>
 

--- a/DesktopRenamer/DesktopRenamer.sdef
+++ b/DesktopRenamer/DesktopRenamer.sdef
@@ -2,6 +2,75 @@
 <!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
 <dictionary title="DesktopRenamer Terminology">
     <suite name="DesktopRenamer Suite" code="DskR" description="Commands for DesktopRenamer">
+
+        <record-type name="api information" code="DskI" description="Structured API capabilities and version information">
+            <property name="contract version" code="Cvrs" type="text"><cocoa key="contractVersion"/></property>
+            <property name="JSON-RPC version" code="JRpc" type="text"><cocoa key="jsonRPCVersion"/></property>
+            <property name="supported methods" code="SMet" type="list of text"><cocoa key="supportedMethods"/></property>
+            <property name="legacy notifications" code="LNot" type="boolean"><cocoa key="legacyNotifications"/></property>
+            <property name="event notifications" code="ENot" type="boolean"><cocoa key="eventNotifications"/></property>
+            <property name="maximum payload bytes" code="MPBy" type="integer"><cocoa key="maxPayloadBytes"/></property>
+        </record-type>
+
+        <record-type name="space" code="DkSp" description="A managed Mission Control space">
+            <property name="id" code="SpID" type="text"><cocoa key="id"/></property>
+            <property name="name" code="SpNm" type="text"><cocoa key="name"/></property>
+            <property name="display ID" code="DsID" type="text"><cocoa key="displayID"/></property>
+            <property name="display name" code="DsNm" type="text"><cocoa key="displayName"/></property>
+            <property name="number" code="SpNo" type="integer"><cocoa key="number"/></property>
+            <property name="full screen" code="Fscr" type="boolean"><cocoa key="isFullscreen"/></property>
+            <property name="app name" code="ApNm" type="text"><cocoa key="appName"/></property>
+            <property name="app path" code="ApPt" type="text"><cocoa key="appPath"/></property>
+            <property name="global shortcut number" code="GsNo" type="integer"><cocoa key="globalShortcutNumber"/></property>
+        </record-type>
+
+        <record-type name="space snapshot" code="DkSn" description="A versioned snapshot of Mission Control spaces">
+            <property name="API version" code="ApiV" type="text"><cocoa key="apiVersion"/></property>
+            <property name="revision" code="RvNo" type="integer"><cocoa key="revision"/></property>
+            <property name="timestamp" code="TmSt" type="text"><cocoa key="timestamp"/></property>
+            <property name="current space IDs" code="CsID" type="list of text"><cocoa key="currentSpaceIDs"/></property>
+            <property name="current space name" code="CsNm" type="text"><cocoa key="currentSpaceName"/></property>
+            <property name="spaces" code="Spcs" type="list of space"><cocoa key="spaces"/></property>
+        </record-type>
+
+        <record-type name="window" code="DkWi" description="An application window assigned to a space">
+            <property name="id" code="WiID" type="integer"><cocoa key="id"/></property>
+            <property name="process ID" code="PrID" type="integer"><cocoa key="pid"/></property>
+            <property name="owner name" code="OwNm" type="text"><cocoa key="ownerName"/></property>
+            <property name="app path" code="WiPt" type="text"><cocoa key="appPath"/></property>
+            <property name="title" code="WiTl" type="text"><cocoa key="title"/></property>
+            <property name="space ID" code="WiSp" type="text"><cocoa key="spaceID"/></property>
+            <property name="minimized" code="MiWd" type="boolean"><cocoa key="isMinimized"/></property>
+            <property name="hidden" code="HiWd" type="boolean"><cocoa key="isHidden"/></property>
+        </record-type>
+
+        <record-type name="window snapshot" code="DkWs" description="A versioned snapshot of spaces and application windows">
+            <property name="API version" code="WApi" type="text"><cocoa key="apiVersion"/></property>
+            <property name="revision" code="WRNo" type="integer"><cocoa key="revision"/></property>
+            <property name="timestamp" code="WTmS" type="text"><cocoa key="timestamp"/></property>
+            <property name="spaces" code="WSpc" type="list of space"><cocoa key="spaces"/></property>
+            <property name="windows" code="WWns" type="list of window"><cocoa key="windows"/></property>
+        </record-type>
+
+        <command name="get api information" code="DskRGInf" description="Get structured API version and capability information">
+            <cocoa class="DesktopRenamer.GetAPIInformationCommand"/>
+            <result type="api information" description="API contract and capability information"/>
+        </command>
+
+        <command name="get structured spaces" code="DskRGSps" description="Get all spaces as typed records">
+            <cocoa class="DesktopRenamer.GetStructuredSpacesCommand"/>
+            <result type="list of space" description="Spaces sorted by display and space number"/>
+        </command>
+
+        <command name="get structured snapshot" code="DskRGSnp" description="Get a versioned typed snapshot of all spaces">
+            <cocoa class="DesktopRenamer.GetStructuredSnapshotCommand"/>
+            <result type="space snapshot" description="Versioned space snapshot"/>
+        </command>
+
+        <command name="get structured windows" code="DskRGWsn" description="Get spaces and windows as typed records">
+            <cocoa class="DesktopRenamer.GetStructuredWindowsCommand"/>
+            <result type="window snapshot" description="Versioned space and window snapshot"/>
+        </command>
         
         <command name="toggle menubar" code="DskRTMen" description="Toggle the visibility of the menubar item">
             <cocoa class="DesktopRenamer.ToggleMenubarCommand"/>

--- a/DesktopRenamer/Models/DesktopSpace.swift
+++ b/DesktopRenamer/Models/DesktopSpace.swift
@@ -9,6 +9,9 @@ struct DesktopSpace: Identifiable, Codable, Equatable {
     var appName: String?
     var appPath: String?
     var globalShortcutNum: Int? // Unified index for keyboard shortcuts (1, 2, 3...) across displays
+    // Unlike ManagedSpaceID, this UUID normally survives a system reboot.
+    // It is optional because macOS can leave it empty for some desktops.
+    var persistentID: String?
     
     // Custom decoding to handle legacy data
     init(from decoder: Decoder) throws {
@@ -21,10 +24,11 @@ struct DesktopSpace: Identifiable, Codable, Equatable {
         appName = try container.decodeIfPresent(String.self, forKey: .appName)
         appPath = try container.decodeIfPresent(String.self, forKey: .appPath)
         globalShortcutNum = try container.decodeIfPresent(Int.self, forKey: .globalShortcutNum)
+        persistentID = try container.decodeIfPresent(String.self, forKey: .persistentID)
     }
     
     // Default init
-    init(id: String, customName: String, num: Int, displayID: String, isFullscreen: Bool = false, appName: String? = nil, appPath: String? = nil, globalShortcutNum: Int? = nil) {
+    init(id: String, customName: String, num: Int, displayID: String, isFullscreen: Bool = false, appName: String? = nil, appPath: String? = nil, globalShortcutNum: Int? = nil, persistentID: String? = nil) {
         self.id = id
         self.customName = customName
         self.num = num
@@ -33,5 +37,6 @@ struct DesktopSpace: Identifiable, Codable, Equatable {
         self.appName = appName
         self.appPath = appPath
         self.globalShortcutNum = globalShortcutNum
+        self.persistentID = persistentID
     }
 }

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -1,5 +1,61 @@
 import Foundation
 
+enum SpaceAPIParameterKind: Equatable {
+    case string
+    case positiveInteger
+    case direction
+    case windowAction
+
+    var description: String {
+        switch self {
+        case .string:
+            return "string"
+        case .positiveInteger:
+            return "positive integer"
+        case .direction:
+            return "one of: up, down"
+        case .windowAction:
+            return "one of: " + DesktopRenamerAPIContract.windowActionNames.joined(separator: ", ")
+        }
+    }
+}
+
+enum SpaceAPIResultKind: Equatable {
+    case operation
+    case boolean
+}
+
+enum SpaceAPIJSONRPCCode {
+    static let parseError = -32700
+    static let invalidRequest = -32600
+    static let methodNotFound = -32601
+    static let invalidParams = -32602
+    static let internalError = -32603
+    static let apiDisabled = -32001
+    static let appUnavailable = -32002
+    static let operationFailed = -32004
+    static let payloadTooLarge = -32006
+}
+
+struct SpaceAPIMethodDefinition: Equatable {
+    let name: String
+    let parameters: [String: SpaceAPIParameterKind]
+    let requiredParameters: Set<String>
+    let resultKind: SpaceAPIResultKind
+
+    init(
+        name: String,
+        parameters: [String: SpaceAPIParameterKind] = [:],
+        requiredParameters: Set<String> = [],
+        resultKind: SpaceAPIResultKind = .operation
+    ) {
+        self.name = name
+        self.parameters = parameters
+        self.requiredParameters = requiredParameters
+        self.resultKind = resultKind
+    }
+}
+
 enum DesktopRenamerAPIContract {
     static let version = "1.0.0"
     static let jsonRPCVersion = "2.0"
@@ -9,71 +65,86 @@ enum DesktopRenamerAPIContract {
     static let rpcRequest = Notification.Name("com.michaelqiu.DesktopRenamer.RPCRequest")
     static let rpcResponse = Notification.Name("com.michaelqiu.DesktopRenamer.RPCResponse")
     static let rpcEvent = Notification.Name("com.michaelqiu.DesktopRenamer.RPCEvent")
-
-    static let supportedMethods = [
-        "getAPIInfo",
-        "getAPIVersion",
-        "getSpaceSnapshot",
-        "getCurrentSpaceName",
-        "getCurrentSpaceID",
-        "getAllSpaces",
-        "switchToSpace",
-        "renameCurrentSpace",
-        "renameSpace",
-        "rearrangeSpace",
-        "moveWindowNext",
-        "moveWindowPrevious",
-        "moveWindowToSpace",
-        "reloadSpaceLabels",
-        "toggleMenubar",
-        "toggleLauncher",
-        "toggleLabels",
-        "toggleActiveLabel",
-        "togglePreviewLabel",
-        "toggleDesktopVisibility",
-        "getWindows",
-        "focusWindow",
-        "executeWindowAction",
-        "moveSpecificWindow"
+    static let windowActionNames = [
+        "close", "minimize", "hide", "enterFullScreen", "exitFullScreen", "quit", "restore"
     ]
 
-    static let allowedParameters: [String: Set<String>] = [
-        "getAPIInfo": [],
-        "getAPIVersion": [],
-        "getSpaceSnapshot": [],
-        "getCurrentSpaceName": [],
-        "getCurrentSpaceID": [],
-        "getAllSpaces": [],
-        "switchToSpace": ["spaceID"],
-        "renameCurrentSpace": ["name"],
-        "renameSpace": ["spaceID", "name"],
-        "rearrangeSpace": ["spaceID", "direction"],
-        "moveWindowNext": [],
-        "moveWindowPrevious": [],
-        "moveWindowToSpace": ["spaceID"],
-        "reloadSpaceLabels": [],
-        "toggleMenubar": [],
-        "toggleLauncher": [],
-        "toggleLabels": [],
-        "toggleActiveLabel": [],
-        "togglePreviewLabel": [],
-        "toggleDesktopVisibility": [],
-        "getWindows": [],
-        "focusWindow": ["windowID", "pid"],
-        "executeWindowAction": ["windowID", "pid", "action"],
-        "moveSpecificWindow": ["windowID", "pid", "fromSpaceID", "targetSpaceID"]
+    static let methodDefinitions = [
+        SpaceAPIMethodDefinition(name: "getAPIInfo"),
+        SpaceAPIMethodDefinition(name: "getAPIVersion"),
+        SpaceAPIMethodDefinition(name: "getSpaceSnapshot"),
+        SpaceAPIMethodDefinition(name: "getCurrentSpaceName"),
+        SpaceAPIMethodDefinition(name: "getCurrentSpaceID"),
+        SpaceAPIMethodDefinition(name: "getAllSpaces"),
+        SpaceAPIMethodDefinition(
+            name: "switchToSpace",
+            parameters: ["spaceID": .string],
+            requiredParameters: ["spaceID"]
+        ),
+        SpaceAPIMethodDefinition(
+            name: "renameCurrentSpace",
+            parameters: ["name": .string],
+            requiredParameters: ["name"]
+        ),
+        SpaceAPIMethodDefinition(
+            name: "renameSpace",
+            parameters: ["spaceID": .string, "name": .string],
+            requiredParameters: ["spaceID", "name"]
+        ),
+        SpaceAPIMethodDefinition(
+            name: "rearrangeSpace",
+            parameters: ["spaceID": .string, "direction": .direction],
+            requiredParameters: ["spaceID", "direction"]
+        ),
+        SpaceAPIMethodDefinition(name: "moveWindowNext"),
+        SpaceAPIMethodDefinition(name: "moveWindowPrevious"),
+        SpaceAPIMethodDefinition(
+            name: "moveWindowToSpace",
+            parameters: ["spaceID": .string],
+            requiredParameters: ["spaceID"]
+        ),
+        SpaceAPIMethodDefinition(name: "reloadSpaceLabels"),
+        SpaceAPIMethodDefinition(name: "toggleMenubar", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "toggleLauncher", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "toggleLabels", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "toggleActiveLabel", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "togglePreviewLabel", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "toggleDesktopVisibility", resultKind: .boolean),
+        SpaceAPIMethodDefinition(name: "getWindows"),
+        SpaceAPIMethodDefinition(
+            name: "focusWindow",
+            parameters: ["windowID": .positiveInteger, "pid": .positiveInteger],
+            requiredParameters: ["windowID", "pid"]
+        ),
+        SpaceAPIMethodDefinition(
+            name: "executeWindowAction",
+            parameters: [
+                "windowID": .positiveInteger,
+                "pid": .positiveInteger,
+                "action": .windowAction
+            ],
+            requiredParameters: ["windowID", "pid", "action"]
+        ),
+        SpaceAPIMethodDefinition(
+            name: "moveSpecificWindow",
+            parameters: [
+                "windowID": .positiveInteger,
+                "pid": .positiveInteger,
+                "fromSpaceID": .string,
+                "targetSpaceID": .string
+            ],
+            requiredParameters: ["windowID", "fromSpaceID", "targetSpaceID"]
+        )
     ]
 
-    static let requiredParameters: [String: Set<String>] = [
-        "switchToSpace": ["spaceID"],
-        "renameCurrentSpace": ["name"],
-        "renameSpace": ["spaceID", "name"],
-        "rearrangeSpace": ["spaceID", "direction"],
-        "moveWindowToSpace": ["spaceID"],
-        "focusWindow": ["windowID", "pid"],
-        "executeWindowAction": ["windowID", "pid", "action"],
-        "moveSpecificWindow": ["windowID", "fromSpaceID", "targetSpaceID"]
-    ]
+    static let supportedMethods = methodDefinitions.map(\.name)
+    private static let methodDefinitionsByName = Dictionary(
+        uniqueKeysWithValues: methodDefinitions.map { ($0.name, $0) }
+    )
+
+    static func definition(for method: String) -> SpaceAPIMethodDefinition? {
+        methodDefinitionsByName[method]
+    }
 }
 
 enum SpaceAPIJSONValue: Codable, Equatable {
@@ -160,7 +231,7 @@ enum SpaceAPIJSONValue: Codable, Equatable {
 
 struct SpaceAPIJSONRPCRequest: Codable, Equatable {
     let jsonrpc: String
-    let id: String?
+    let id: String
     let method: String
     let params: SpaceAPIJSONValue?
 
@@ -174,7 +245,7 @@ struct SpaceAPIJSONRPCRequest: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
-        id = try container.decodeIfPresent(String.self, forKey: .id)
+        id = try container.decode(String.self, forKey: .id)
         method = try container.decode(String.self, forKey: .method)
         params = container.contains(.params) ? try container.decode(SpaceAPIJSONValue.self, forKey: .params) : nil
     }
@@ -216,9 +287,22 @@ struct SpaceAPIJSONRPCResponse: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        guard container.contains(.id) else {
+            throw SpaceAPIContractError.invalidRequest("A JSON-RPC response requires an ID, including null when unknown.")
+        }
         id = try container.decodeIfPresent(String.self, forKey: .id)
         result = container.contains(.result) ? try container.decode(SpaceAPIJSONValue.self, forKey: .result) : nil
         error = container.contains(.error) ? try container.decode(SpaceAPIJSONRPCError.self, forKey: .error) : nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(jsonrpc, forKey: .jsonrpc)
+        // JSON-RPC requires an explicit null ID when the request ID cannot be
+        // recovered (for example, after a parse error).
+        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(result, forKey: .result)
+        try container.encodeIfPresent(error, forKey: .error)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -263,6 +347,66 @@ struct SpaceAPISpace: Codable, Equatable {
     let appName: String?
     let appPath: String?
     let globalShortcutNumber: Int?
+
+    init(
+        id: String,
+        name: String,
+        displayID: String,
+        displayName: String,
+        number: Int,
+        isFullscreen: Bool,
+        appName: String?,
+        appPath: String?,
+        globalShortcutNumber: Int?
+    ) {
+        self.id = id
+        self.name = name
+        self.displayID = displayID
+        self.displayName = displayName
+        self.number = number
+        self.isFullscreen = isFullscreen
+        self.appName = appName
+        self.appPath = appPath
+        self.globalShortcutNumber = globalShortcutNumber
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        displayID = try container.decode(String.self, forKey: .displayID)
+        displayName = try container.decode(String.self, forKey: .displayName)
+        number = try container.decode(Int.self, forKey: .number)
+        isFullscreen = try container.decode(Bool.self, forKey: .isFullscreen)
+        appName = try container.decodeIfPresent(String.self, forKey: .appName)
+        appPath = try container.decodeIfPresent(String.self, forKey: .appPath)
+        globalShortcutNumber = try container.decodeIfPresent(Int.self, forKey: .globalShortcutNumber)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(displayID, forKey: .displayID)
+        try container.encode(displayName, forKey: .displayName)
+        try container.encode(number, forKey: .number)
+        try container.encode(isFullscreen, forKey: .isFullscreen)
+        try container.encode(appName, forKey: .appName)
+        try container.encode(appPath, forKey: .appPath)
+        try container.encode(globalShortcutNumber, forKey: .globalShortcutNumber)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case displayID
+        case displayName
+        case number
+        case isFullscreen
+        case appName
+        case appPath
+        case globalShortcutNumber
+    }
 }
 
 struct SpaceAPIWindow: Codable, Equatable {
@@ -274,6 +418,61 @@ struct SpaceAPIWindow: Codable, Equatable {
     let spaceID: String
     let isMinimized: Bool
     let isHidden: Bool
+
+    init(
+        id: Int,
+        pid: Int32,
+        ownerName: String,
+        appPath: String?,
+        title: String?,
+        spaceID: String,
+        isMinimized: Bool,
+        isHidden: Bool
+    ) {
+        self.id = id
+        self.pid = pid
+        self.ownerName = ownerName
+        self.appPath = appPath
+        self.title = title
+        self.spaceID = spaceID
+        self.isMinimized = isMinimized
+        self.isHidden = isHidden
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(Int.self, forKey: .id)
+        pid = try container.decode(Int32.self, forKey: .pid)
+        ownerName = try container.decode(String.self, forKey: .ownerName)
+        appPath = try container.decodeIfPresent(String.self, forKey: .appPath)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        spaceID = try container.decode(String.self, forKey: .spaceID)
+        isMinimized = try container.decode(Bool.self, forKey: .isMinimized)
+        isHidden = try container.decode(Bool.self, forKey: .isHidden)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(pid, forKey: .pid)
+        try container.encode(ownerName, forKey: .ownerName)
+        try container.encode(appPath, forKey: .appPath)
+        try container.encode(title, forKey: .title)
+        try container.encode(spaceID, forKey: .spaceID)
+        try container.encode(isMinimized, forKey: .isMinimized)
+        try container.encode(isHidden, forKey: .isHidden)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case pid
+        case ownerName
+        case appPath
+        case title
+        case spaceID
+        case isMinimized
+        case isHidden
+    }
 }
 
 struct SpaceAPISnapshot: Codable, Equatable {
@@ -329,10 +528,150 @@ enum SpaceAPIContractError: LocalizedError, Equatable {
     }
 }
 
+enum SpaceAPIArgumentValidator {
+    static func stringArguments(from params: SpaceAPIJSONValue?, method: String) throws -> [String: String] {
+        guard let definition = DesktopRenamerAPIContract.definition(for: method) else {
+            throw SpaceAPIContractError.unsupportedMethod(method)
+        }
+
+        guard let params else {
+            return try validateRequiredParameters([:], definition: definition)
+        }
+        guard let object = params.objectValue else {
+            throw invalidParameter(
+                method: method,
+                name: "params",
+                expected: "object",
+                message: "Parameters must be a JSON object."
+            )
+        }
+
+        let allowedParameters = Set(definition.parameters.keys)
+        if let unknownParameter = object.keys.sorted().first(where: { !allowedParameters.contains($0) }) {
+            throw invalidParameter(
+                method: method,
+                name: unknownParameter,
+                expected: "a supported parameter",
+                message: "Parameter '\(unknownParameter)' is not supported for \(method)."
+            )
+        }
+
+        let arguments = try object.reduce(into: [String: String]()) { result, item in
+            guard let kind = definition.parameters[item.key] else { return }
+            let expected = kind.description
+            switch item.value {
+            case .string(let value):
+                if kind == .positiveInteger, !isPositiveInteger(value, parameter: item.key) {
+                    throw invalidParameter(
+                        method: method,
+                        name: item.key,
+                        expected: expected,
+                        message: "Parameter '\(item.key)' must be a positive integer."
+                    )
+                }
+                if kind == .direction {
+                    let direction = value.lowercased()
+                    guard direction == "up" || direction == "down" else {
+                        throw invalidParameter(
+                            method: method,
+                            name: item.key,
+                            expected: expected,
+                            message: "Parameter '\(item.key)' must be either 'up' or 'down'."
+                        )
+                    }
+                    result[item.key] = direction
+                } else if kind == .windowAction {
+                    guard DesktopRenamerAPIContract.windowActionNames.contains(value) else {
+                        throw invalidParameter(
+                            method: method,
+                            name: item.key,
+                            expected: expected,
+                            message: "Parameter '\(item.key)' is not a supported window action."
+                        )
+                    }
+                    result[item.key] = value
+                } else {
+                    result[item.key] = value
+                }
+            case .number(let value) where value.isFinite && value.rounded() == value && kind == .positiveInteger:
+                guard let integer = Int(exactly: value) else {
+                    throw invalidParameter(
+                        method: method,
+                        name: item.key,
+                        expected: expected,
+                        message: "Parameter '\(item.key)' is outside the supported integer range."
+                    )
+                }
+                guard integer > 0 else {
+                    throw invalidParameter(
+                        method: method,
+                        name: item.key,
+                        expected: expected,
+                        message: "Parameter '\(item.key)' must be a positive integer."
+                    )
+                }
+                result[item.key] = String(integer)
+            default:
+                throw invalidParameter(
+                    method: method,
+                    name: item.key,
+                    expected: expected,
+                    message: "Parameter '\(item.key)' must be \(typeDescription(expected))."
+                )
+            }
+        }
+
+        return try validateRequiredParameters(arguments, definition: definition)
+    }
+
+    private static func validateRequiredParameters(
+        _ arguments: [String: String],
+        definition: SpaceAPIMethodDefinition
+    ) throws -> [String: String] {
+        for parameter in definition.requiredParameters.sorted() {
+            guard let value = arguments[parameter], !value.isEmpty else {
+                throw invalidParameter(
+                    method: definition.name,
+                    name: parameter,
+                    expected: definition.parameters[parameter]?.description ?? "string",
+                    message: "Missing required parameter '\(parameter)'."
+                )
+            }
+        }
+        return arguments
+    }
+
+    private static func isPositiveInteger(_ value: String, parameter: String) -> Bool {
+        if parameter == "pid", let pid = Int32(value) {
+            return pid > 0
+        }
+        if parameter == "windowID", let windowID = Int(value) {
+            return windowID > 0
+        }
+        return Int(value).map { $0 > 0 } ?? false
+    }
+
+    private static func typeDescription(_ expected: String) -> String {
+        expected.hasPrefix("one of:") ? expected : "a \(expected)"
+    }
+
+    private static func invalidParameter(
+        method: String,
+        name: String,
+        expected: String,
+        message: String
+    ) -> SpaceAPIContractError {
+        .invalidParamsWithData(
+            message,
+            SpaceAPIErrorData(parameter: name, expected: expected, command: method)
+        )
+    }
+}
+
 enum SpaceAPIJSONRPCCodec {
     static func encode(_ request: SpaceAPIJSONRPCRequest) throws -> String {
         guard request.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion,
-              let id = request.id, !id.isEmpty,
+              !request.id.isEmpty,
               !request.method.isEmpty, request.method.count <= 128 else {
             throw SpaceAPIContractError.invalidRequest("A JSON-RPC request requires a non-empty ID and method.")
         }
@@ -356,7 +695,7 @@ enum SpaceAPIJSONRPCCodec {
         guard request.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
             throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 requests are supported.")
         }
-        guard let id = request.id, !id.isEmpty else {
+        guard !request.id.isEmpty else {
             throw SpaceAPIContractError.invalidRequest("A non-empty string request ID is required.")
         }
         guard !request.method.isEmpty, request.method.count <= 128 else {
@@ -382,16 +721,7 @@ enum SpaceAPIJSONRPCCodec {
         guard response.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
             throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 responses are supported.")
         }
-        if let id = response.id, id.isEmpty {
-            throw SpaceAPIContractError.invalidRequest("A response ID must be a non-empty string when present.")
-        }
-        guard (response.result == nil) != (response.error == nil) else {
-            throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
-        }
-        if let error = response.error, error.message.isEmpty {
-            throw SpaceAPIContractError.invalidRequest("A JSON-RPC error requires a message.")
-        }
-        return response
+        return try validateResponse(response)
     }
 
     static func decodeEvent(_ payload: String) throws -> SpaceAPIJSONRPCEvent {
@@ -405,6 +735,10 @@ enum SpaceAPIJSONRPCCodec {
             throw SpaceAPIContractError.invalidRequest("Event is not a valid JSON-RPC 2.0 notification.")
         }
 
+        if let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) as? [String: Any],
+           object["id"] != nil {
+            throw SpaceAPIContractError.invalidRequest("JSON-RPC events must not contain an ID.")
+        }
         guard event.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
             throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 events are supported.")
         }
@@ -421,13 +755,7 @@ enum SpaceAPIJSONRPCCodec {
         guard response.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
             throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 responses are supported.")
         }
-        if let id = response.id, id.isEmpty {
-            throw SpaceAPIContractError.invalidRequest("A response ID must be a non-empty string when present.")
-        }
-        guard (response.result == nil) != (response.error == nil) else {
-            throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
-        }
-        return try encodeJSON(response)
+        return try encodeJSON(try validateResponse(response))
     }
 
     static func encode(_ event: SpaceAPIJSONRPCEvent) throws -> String {
@@ -489,30 +817,57 @@ enum SpaceAPIJSONRPCCodec {
         }
     }
 
+    private static func validateResponse(_ response: SpaceAPIJSONRPCResponse) throws -> SpaceAPIJSONRPCResponse {
+        if let id = response.id, id.isEmpty {
+            throw SpaceAPIContractError.invalidRequest("A response ID must be a non-empty string when present.")
+        }
+        if response.id == nil, response.result != nil {
+            throw SpaceAPIContractError.invalidRequest("A successful response requires a non-null request ID.")
+        }
+        guard (response.result == nil) != (response.error == nil) else {
+            throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
+        }
+        if let error = response.error, error.message.isEmpty {
+            throw SpaceAPIContractError.invalidRequest("A JSON-RPC error requires a message.")
+        }
+        return response
+    }
+
 }
 
 extension SpaceAPIContractError {
     var jsonRPCCode: Int {
         switch self {
         case .invalidJSON:
-            return -32700
+            return SpaceAPIJSONRPCCode.parseError
         case .invalidRequest:
-            return -32600
+            return SpaceAPIJSONRPCCode.invalidRequest
         case .invalidParams:
-            return -32602
+            return SpaceAPIJSONRPCCode.invalidParams
         case .invalidParamsWithData:
-            return -32602
+            return SpaceAPIJSONRPCCode.invalidParams
         case .unsupportedMethod:
-            return -32601
+            return SpaceAPIJSONRPCCode.methodNotFound
         case .payloadTooLarge:
-            return -32006
+            return SpaceAPIJSONRPCCode.payloadTooLarge
         }
     }
 
     var jsonRPCData: SpaceAPIErrorData? {
+        jsonRPCData(command: nil)
+    }
+
+    func jsonRPCData(command: String?) -> SpaceAPIErrorData? {
         switch self {
         case .invalidParamsWithData(_, let data):
-            return data
+            guard data.command == nil, let command else { return data }
+            return SpaceAPIErrorData(
+                parameter: data.parameter,
+                expected: data.expected,
+                command: command
+            )
+        case .invalidParams:
+            return command.map { SpaceAPIErrorData(command: $0) }
         case .unsupportedMethod(let method):
             return SpaceAPIErrorData(command: method)
         default:

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -1,0 +1,332 @@
+import Foundation
+
+enum DesktopRenamerAPIContract {
+    static let version = "1.2.0"
+    static let jsonRPCVersion = "2.0"
+    static let payloadKey = "payload"
+    static let maxPayloadBytes = 1_048_576
+
+    static let rpcRequest = Notification.Name("com.michaelqiu.DesktopRenamer.RPCRequest")
+    static let rpcResponse = Notification.Name("com.michaelqiu.DesktopRenamer.RPCResponse")
+    static let rpcEvent = Notification.Name("com.michaelqiu.DesktopRenamer.RPCEvent")
+
+    static let supportedMethods = [
+        "getAPIInfo",
+        "getAPIVersion",
+        "getSpaceSnapshot",
+        "getCurrentSpaceName",
+        "getCurrentSpaceID",
+        "getAllSpaces",
+        "switchToSpace",
+        "renameCurrentSpace",
+        "renameSpace",
+        "rearrangeSpace",
+        "moveWindowNext",
+        "moveWindowPrevious",
+        "moveWindowToSpace",
+        "reloadSpaceLabels",
+        "toggleMenubar",
+        "toggleLauncher",
+        "toggleLabels",
+        "toggleActiveLabel",
+        "togglePreviewLabel",
+        "toggleDesktopVisibility",
+        "getWindows",
+        "focusWindow",
+        "executeWindowAction",
+        "moveSpecificWindow"
+    ]
+}
+
+enum SpaceAPIJSONValue: Codable, Equatable {
+    case object([String: SpaceAPIJSONValue])
+    case array([SpaceAPIJSONValue])
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode([String: SpaceAPIJSONValue].self) {
+            self = .object(value)
+        } else if let value = try? container.decode([SpaceAPIJSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Double.self) {
+            guard value.isFinite else {
+                throw SpaceAPIContractError.invalidJSON("JSON numbers must be finite.")
+            }
+            self = .number(value)
+        } else {
+            throw SpaceAPIContractError.invalidJSON("Unsupported JSON value.")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .number(let value):
+            guard value.isFinite else {
+                throw SpaceAPIContractError.invalidJSON("JSON numbers must be finite.")
+            }
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+
+    static func from<T: Encodable>(_ value: T, using encoder: JSONEncoder = JSONEncoder()) throws -> SpaceAPIJSONValue {
+        try decoder.decode(SpaceAPIJSONValue.self, from: encoder.encode(value))
+    }
+
+    func decode<T: Decodable>(_ type: T.Type, using decoder: JSONDecoder = JSONDecoder()) throws -> T {
+        try decoder.decode(type, from: JSONEncoder().encode(self))
+    }
+
+    private static let decoder = JSONDecoder()
+
+    var objectValue: [String: SpaceAPIJSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    var intValue: Int? {
+        guard case .number(let value) = self, value.rounded() == value else { return nil }
+        return Int(exactly: value)
+    }
+}
+
+struct SpaceAPIJSONRPCRequest: Codable, Equatable {
+    let jsonrpc: String
+    let id: String?
+    let method: String
+    let params: SpaceAPIJSONValue?
+
+    init(id: String, method: String, params: [String: SpaceAPIJSONValue] = [:]) {
+        self.jsonrpc = DesktopRenamerAPIContract.jsonRPCVersion
+        self.id = id
+        self.method = method
+        self.params = params.isEmpty ? nil : .object(params)
+    }
+}
+
+struct SpaceAPIJSONRPCError: Codable, Equatable {
+    let code: Int
+    let message: String
+    let data: SpaceAPIJSONValue?
+}
+
+struct SpaceAPIJSONRPCResponse: Codable, Equatable {
+    let jsonrpc: String
+    let id: String?
+    let result: SpaceAPIJSONValue?
+    let error: SpaceAPIJSONRPCError?
+
+    init(id: String?, result: SpaceAPIJSONValue) {
+        self.jsonrpc = DesktopRenamerAPIContract.jsonRPCVersion
+        self.id = id
+        self.result = result
+        self.error = nil
+    }
+
+    init(id: String?, error: SpaceAPIJSONRPCError) {
+        self.jsonrpc = DesktopRenamerAPIContract.jsonRPCVersion
+        self.id = id
+        self.result = nil
+        self.error = error
+    }
+}
+
+struct SpaceAPIErrorData: Codable, Equatable {
+    let parameter: String?
+    let expected: String?
+    let command: String?
+
+    init(parameter: String? = nil, expected: String? = nil, command: String? = nil) {
+        self.parameter = parameter
+        self.expected = expected
+        self.command = command
+    }
+}
+
+struct SpaceAPISpace: Codable, Equatable {
+    let id: String
+    let name: String
+    let displayID: String
+    let displayName: String
+    let number: Int
+    let isFullscreen: Bool
+    let appName: String?
+    let appPath: String?
+    let globalShortcutNumber: Int?
+}
+
+struct SpaceAPIWindow: Codable, Equatable {
+    let id: Int
+    let pid: Int32
+    let ownerName: String
+    let appPath: String?
+    let title: String?
+    let spaceID: String
+    let isMinimized: Bool
+    let isHidden: Bool
+}
+
+struct SpaceAPISnapshot: Codable, Equatable {
+    let apiVersion: String
+    let revision: UInt64
+    let timestamp: String
+    let currentSpaceIDs: [String]
+    let currentSpaceName: String
+    let spaces: [SpaceAPISpace]
+}
+
+struct SpaceAPIWindowsSnapshot: Codable, Equatable {
+    let apiVersion: String
+    let revision: UInt64
+    let timestamp: String
+    let spaces: [SpaceAPISpace]
+    let windows: [SpaceAPIWindow]
+}
+
+struct SpaceAPIOperationResult: Codable, Equatable {
+    let accepted: Bool
+}
+
+struct SpaceAPIInfo: Codable, Equatable {
+    let contractVersion: String
+    let jsonRPCVersion: String
+    let supportedMethods: [String]
+    let legacyNotifications: Bool
+    let eventNotifications: Bool
+    let maxPayloadBytes: Int
+}
+
+enum SpaceAPIContractError: LocalizedError, Equatable {
+    case invalidJSON(String)
+    case invalidRequest(String)
+    case invalidParams(String)
+    case payloadTooLarge
+    case unsupportedMethod(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidJSON(let message), .invalidRequest(let message), .invalidParams(let message):
+            return message
+        case .payloadTooLarge:
+            return "SpaceAPI payload exceeds the maximum size."
+        case .unsupportedMethod(let method):
+            return "Unsupported SpaceAPI method: \(method)"
+        }
+    }
+}
+
+enum SpaceAPIJSONRPCCodec {
+    static func decodeRequest(_ payload: String) throws -> SpaceAPIJSONRPCRequest {
+        try validatePayloadSize(payload)
+        guard let data = payload.data(using: .utf8) else {
+            throw SpaceAPIContractError.invalidJSON("Payload is not valid UTF-8.")
+        }
+
+        let request: SpaceAPIJSONRPCRequest
+        do {
+            request = try JSONDecoder().decode(SpaceAPIJSONRPCRequest.self, from: data)
+        } catch {
+            throw SpaceAPIContractError.invalidRequest("Request is not a valid JSON-RPC 2.0 object.")
+        }
+
+        guard request.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
+            throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 requests are supported.")
+        }
+        guard let id = request.id, !id.isEmpty else {
+            throw SpaceAPIContractError.invalidRequest("A non-empty string request ID is required.")
+        }
+        guard !request.method.isEmpty, request.method.count <= 128 else {
+            throw SpaceAPIContractError.invalidRequest("A non-empty method name of at most 128 characters is required.")
+        }
+        if let params = request.params, params.objectValue == nil {
+            throw SpaceAPIContractError.invalidParams("Named parameters must be a JSON object.")
+        }
+        return request
+    }
+
+    static func encode(_ response: SpaceAPIJSONRPCResponse) throws -> String {
+        guard (response.result == nil) != (response.error == nil) else {
+            throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(response)
+        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
+            throw SpaceAPIContractError.payloadTooLarge
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    static func errorResponse(
+        id: String?,
+        code: Int,
+        message: String,
+        data: SpaceAPIErrorData? = nil
+    ) -> SpaceAPIJSONRPCResponse {
+        let encodedData: SpaceAPIJSONValue?
+        if let data {
+            encodedData = try? SpaceAPIJSONValue.from(data)
+        } else {
+            encodedData = nil
+        }
+        return SpaceAPIJSONRPCResponse(
+            id: id,
+            error: SpaceAPIJSONRPCError(code: code, message: message, data: encodedData)
+        )
+    }
+
+    private static func validatePayloadSize(_ payload: String) throws {
+        guard payload.utf8.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
+            throw SpaceAPIContractError.payloadTooLarge
+        }
+    }
+}
+
+extension SpaceAPIContractError {
+    var jsonRPCCode: Int {
+        switch self {
+        case .invalidJSON:
+            return -32700
+        case .invalidRequest:
+            return -32600
+        case .invalidParams:
+            return -32602
+        case .unsupportedMethod:
+            return -32601
+        case .payloadTooLarge:
+            return -32006
+        }
+    }
+}

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -163,6 +163,18 @@ struct SpaceAPIJSONRPCResponse: Codable, Equatable {
     }
 }
 
+struct SpaceAPIJSONRPCEvent: Codable, Equatable {
+    let jsonrpc: String
+    let method: String
+    let params: SpaceAPIJSONValue
+
+    init(method: String, params: SpaceAPIJSONValue) {
+        self.jsonrpc = DesktopRenamerAPIContract.jsonRPCVersion
+        self.method = method
+        self.params = params
+    }
+}
+
 struct SpaceAPIErrorData: Codable, Equatable {
     let parameter: String?
     let expected: String?
@@ -283,6 +295,16 @@ enum SpaceAPIJSONRPCCodec {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         let data = try encoder.encode(response)
+        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
+            throw SpaceAPIContractError.payloadTooLarge
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    static func encode(_ event: SpaceAPIJSONRPCEvent) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(event)
         guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
             throw SpaceAPIContractError.payloadTooLarge
         }

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -170,6 +170,21 @@ struct SpaceAPIJSONRPCRequest: Codable, Equatable {
         self.method = method
         self.params = params.isEmpty ? nil : .object(params)
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        method = try container.decode(String.self, forKey: .method)
+        params = container.contains(.params) ? try container.decode(SpaceAPIJSONValue.self, forKey: .params) : nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case method
+        case params
+    }
 }
 
 struct SpaceAPIJSONRPCError: Codable, Equatable {
@@ -196,6 +211,21 @@ struct SpaceAPIJSONRPCResponse: Codable, Equatable {
         self.id = id
         self.result = nil
         self.error = error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        result = container.contains(.result) ? try container.decode(SpaceAPIJSONValue.self, forKey: .result) : nil
+        error = container.contains(.error) ? try container.decode(SpaceAPIJSONRPCError.self, forKey: .error) : nil
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case result
+        case error
     }
 }
 

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -36,6 +36,44 @@ enum DesktopRenamerAPIContract {
         "executeWindowAction",
         "moveSpecificWindow"
     ]
+
+    static let allowedParameters: [String: Set<String>] = [
+        "getAPIInfo": [],
+        "getAPIVersion": [],
+        "getSpaceSnapshot": [],
+        "getCurrentSpaceName": [],
+        "getCurrentSpaceID": [],
+        "getAllSpaces": [],
+        "switchToSpace": ["spaceID"],
+        "renameCurrentSpace": ["name"],
+        "renameSpace": ["spaceID", "name"],
+        "rearrangeSpace": ["spaceID", "direction"],
+        "moveWindowNext": [],
+        "moveWindowPrevious": [],
+        "moveWindowToSpace": ["spaceID"],
+        "reloadSpaceLabels": [],
+        "toggleMenubar": [],
+        "toggleLauncher": [],
+        "toggleLabels": [],
+        "toggleActiveLabel": [],
+        "togglePreviewLabel": [],
+        "toggleDesktopVisibility": [],
+        "getWindows": [],
+        "focusWindow": ["windowID", "pid"],
+        "executeWindowAction": ["windowID", "pid", "action"],
+        "moveSpecificWindow": ["windowID", "pid", "fromSpaceID", "targetSpaceID"]
+    ]
+
+    static let requiredParameters: [String: Set<String>] = [
+        "switchToSpace": ["spaceID"],
+        "renameCurrentSpace": ["name"],
+        "renameSpace": ["spaceID", "name"],
+        "rearrangeSpace": ["spaceID", "direction"],
+        "moveWindowToSpace": ["spaceID"],
+        "focusWindow": ["windowID", "pid"],
+        "executeWindowAction": ["windowID", "pid", "action"],
+        "moveSpecificWindow": ["windowID", "fromSpaceID", "targetSpaceID"]
+    ]
 }
 
 enum SpaceAPIJSONValue: Codable, Equatable {
@@ -92,14 +130,12 @@ enum SpaceAPIJSONValue: Codable, Equatable {
     }
 
     static func from<T: Encodable>(_ value: T, using encoder: JSONEncoder = JSONEncoder()) throws -> SpaceAPIJSONValue {
-        try decoder.decode(SpaceAPIJSONValue.self, from: encoder.encode(value))
+        try JSONDecoder().decode(SpaceAPIJSONValue.self, from: encoder.encode(value))
     }
 
     func decode<T: Decodable>(_ type: T.Type, using decoder: JSONDecoder = JSONDecoder()) throws -> T {
         try decoder.decode(type, from: JSONEncoder().encode(self))
     }
-
-    private static let decoder = JSONDecoder()
 
     var objectValue: [String: SpaceAPIJSONValue]? {
         guard case .object(let value) = self else { return nil }
@@ -236,7 +272,9 @@ struct SpaceAPIInfo: Codable, Equatable {
     let jsonRPCVersion: String
     let supportedMethods: [String]
     let legacyNotifications: Bool
+    let legacyCompatibility: String
     let eventNotifications: Bool
+    let eventCapabilities: [String]
     let maxPayloadBytes: Int
 }
 
@@ -244,12 +282,14 @@ enum SpaceAPIContractError: LocalizedError, Equatable {
     case invalidJSON(String)
     case invalidRequest(String)
     case invalidParams(String)
+    case invalidParamsWithData(String, SpaceAPIErrorData)
     case payloadTooLarge
     case unsupportedMethod(String)
 
     var errorDescription: String? {
         switch self {
-        case .invalidJSON(let message), .invalidRequest(let message), .invalidParams(let message):
+        case .invalidJSON(let message), .invalidRequest(let message), .invalidParams(let message),
+             .invalidParamsWithData(let message, _):
             return message
         case .payloadTooLarge:
             return "SpaceAPI payload exceeds the maximum size."
@@ -260,11 +300,21 @@ enum SpaceAPIContractError: LocalizedError, Equatable {
 }
 
 enum SpaceAPIJSONRPCCodec {
-    static func decodeRequest(_ payload: String) throws -> SpaceAPIJSONRPCRequest {
-        try validatePayloadSize(payload)
-        guard let data = payload.data(using: .utf8) else {
-            throw SpaceAPIContractError.invalidJSON("Payload is not valid UTF-8.")
+    static func encode(_ request: SpaceAPIJSONRPCRequest) throws -> String {
+        guard request.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion,
+              let id = request.id, !id.isEmpty,
+              !request.method.isEmpty, request.method.count <= 128 else {
+            throw SpaceAPIContractError.invalidRequest("A JSON-RPC request requires a non-empty ID and method.")
         }
+        if let params = request.params, params.objectValue == nil {
+            throw SpaceAPIContractError.invalidParams("Named parameters must be a JSON object.")
+        }
+        return try encodeJSON(request)
+    }
+
+    static func decodeRequest(_ payload: String) throws -> SpaceAPIJSONRPCRequest {
+        let data = try validatedPayloadData(payload)
+        try requireJSONObject(data, message: "Request must be a JSON object.")
 
         let request: SpaceAPIJSONRPCRequest
         do {
@@ -288,27 +338,75 @@ enum SpaceAPIJSONRPCCodec {
         return request
     }
 
-    static func encode(_ response: SpaceAPIJSONRPCResponse) throws -> String {
+    static func decodeResponse(_ payload: String) throws -> SpaceAPIJSONRPCResponse {
+        let data = try validatedPayloadData(payload)
+        try requireJSONObject(data, message: "Response must be a JSON object.")
+
+        let response: SpaceAPIJSONRPCResponse
+        do {
+            response = try JSONDecoder().decode(SpaceAPIJSONRPCResponse.self, from: data)
+        } catch {
+            throw SpaceAPIContractError.invalidRequest("Response is not a valid JSON-RPC 2.0 object.")
+        }
+
+        guard response.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
+            throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 responses are supported.")
+        }
+        if let id = response.id, id.isEmpty {
+            throw SpaceAPIContractError.invalidRequest("A response ID must be a non-empty string when present.")
+        }
         guard (response.result == nil) != (response.error == nil) else {
             throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
         }
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let data = try encoder.encode(response)
-        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
-            throw SpaceAPIContractError.payloadTooLarge
+        if let error = response.error, error.message.isEmpty {
+            throw SpaceAPIContractError.invalidRequest("A JSON-RPC error requires a message.")
         }
-        return String(decoding: data, as: UTF8.self)
+        return response
+    }
+
+    static func decodeEvent(_ payload: String) throws -> SpaceAPIJSONRPCEvent {
+        let data = try validatedPayloadData(payload)
+        try requireJSONObject(data, message: "Event must be a JSON object.")
+
+        let event: SpaceAPIJSONRPCEvent
+        do {
+            event = try JSONDecoder().decode(SpaceAPIJSONRPCEvent.self, from: data)
+        } catch {
+            throw SpaceAPIContractError.invalidRequest("Event is not a valid JSON-RPC 2.0 notification.")
+        }
+
+        guard event.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
+            throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 events are supported.")
+        }
+        guard !event.method.isEmpty, event.method.count <= 128 else {
+            throw SpaceAPIContractError.invalidRequest("A non-empty event method of at most 128 characters is required.")
+        }
+        guard event.params.objectValue != nil else {
+            throw SpaceAPIContractError.invalidParams("Event parameters must be a JSON object.")
+        }
+        return event
+    }
+
+    static func encode(_ response: SpaceAPIJSONRPCResponse) throws -> String {
+        guard response.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion else {
+            throw SpaceAPIContractError.invalidRequest("Only JSON-RPC 2.0 responses are supported.")
+        }
+        if let id = response.id, id.isEmpty {
+            throw SpaceAPIContractError.invalidRequest("A response ID must be a non-empty string when present.")
+        }
+        guard (response.result == nil) != (response.error == nil) else {
+            throw SpaceAPIContractError.invalidRequest("A response must contain exactly one of result or error.")
+        }
+        return try encodeJSON(response)
     }
 
     static func encode(_ event: SpaceAPIJSONRPCEvent) throws -> String {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys]
-        let data = try encoder.encode(event)
-        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
-            throw SpaceAPIContractError.payloadTooLarge
+        guard event.jsonrpc == DesktopRenamerAPIContract.jsonRPCVersion,
+              !event.method.isEmpty, event.method.count <= 128,
+              event.params.objectValue != nil else {
+            throw SpaceAPIContractError.invalidRequest("Events require JSON-RPC 2.0, a method, and object parameters.")
         }
-        return String(decoding: data, as: UTF8.self)
+        return try encodeJSON(event)
     }
 
     static func errorResponse(
@@ -329,11 +427,38 @@ enum SpaceAPIJSONRPCCodec {
         )
     }
 
-    private static func validatePayloadSize(_ payload: String) throws {
+    private static func encodeJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
+            throw SpaceAPIContractError.payloadTooLarge
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func validatedPayloadData(_ payload: String) throws -> Data {
         guard payload.utf8.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
             throw SpaceAPIContractError.payloadTooLarge
         }
+        guard let data = payload.data(using: .utf8) else {
+            throw SpaceAPIContractError.invalidJSON("Payload is not valid UTF-8.")
+        }
+        do {
+            _ = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        } catch {
+            throw SpaceAPIContractError.invalidJSON("Payload is not valid JSON.")
+        }
+        return data
     }
+
+    private static func requireJSONObject(_ data: Data, message: String) throws {
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+              object is [String: Any] else {
+            throw SpaceAPIContractError.invalidRequest(message)
+        }
+    }
+
 }
 
 extension SpaceAPIContractError {
@@ -345,10 +470,23 @@ extension SpaceAPIContractError {
             return -32600
         case .invalidParams:
             return -32602
+        case .invalidParamsWithData:
+            return -32602
         case .unsupportedMethod:
             return -32601
         case .payloadTooLarge:
             return -32006
+        }
+    }
+
+    var jsonRPCData: SpaceAPIErrorData? {
+        switch self {
+        case .invalidParamsWithData(_, let data):
+            return data
+        case .unsupportedMethod(let method):
+            return SpaceAPIErrorData(command: method)
+        default:
+            return nil
         }
     }
 }

--- a/DesktopRenamer/Services/API/APIContract.swift
+++ b/DesktopRenamer/Services/API/APIContract.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum DesktopRenamerAPIContract {
-    static let version = "1.2.0"
+    static let version = "1.0.0"
     static let jsonRPCVersion = "2.0"
     static let payloadKey = "payload"
     static let maxPayloadBytes = 1_048_576

--- a/DesktopRenamer/Services/API/APITester.swift
+++ b/DesktopRenamer/Services/API/APITester.swift
@@ -1,33 +1,57 @@
 import Foundation
 import Combine
 
-// Helper class for testing SpaceAPI functionality.
-class APITester: ObservableObject {
+// Helper class for testing both compatibility and structured SpaceAPI paths.
+final class APITester: NSObject, ObservableObject {
     @Published var responseText: String = ""
+    @Published var structuredResponseText: String = ""
 
-    init() {
-        NotificationCenter.default.addObserver(
+    private let distributedCenter = DistributedNotificationCenter.default()
+
+    override init() {
+        super.init()
+
+        distributedCenter.addObserver(
             self, selector: #selector(handleCurrentSpaceResponse(_:)),
-            name: SpaceAPI.returnActiveSpace, object: nil)
-        NotificationCenter.default.addObserver(
+            name: SpaceAPI.returnActiveSpace, object: nil, suspensionBehavior: .deliverImmediately)
+        distributedCenter.addObserver(
             self, selector: #selector(handleAllSpacesResponse(_:)), name: SpaceAPI.returnSpaceList,
-            object: nil)
+            object: nil, suspensionBehavior: .deliverImmediately)
+        distributedCenter.addObserver(
+            self, selector: #selector(handleRPCResponse(_:)), name: SpaceAPI.rpcResponse,
+            object: nil, suspensionBehavior: .deliverImmediately)
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        distributedCenter.removeObserver(self)
     }
 
     func sendCurrentSpaceRequest() {
         responseText = "Requesting current space..."
-        DistributedNotificationCenter.default().postNotificationName(
+        distributedCenter.postNotificationName(
             SpaceAPI.getActiveSpace, object: nil, userInfo: nil, deliverImmediately: true)
     }
 
     func sendAllSpacesRequest() {
         responseText = "Requesting all spaces..."
-        DistributedNotificationCenter.default().postNotificationName(
+        distributedCenter.postNotificationName(
             SpaceAPI.getSpaceList, object: nil, userInfo: nil, deliverImmediately: true)
+    }
+
+    func sendStructuredAPIInfoRequest() {
+        let request = SpaceAPIJSONRPCRequest(id: UUID().uuidString, method: "getAPIInfo")
+        do {
+            let payload = try SpaceAPIJSONRPCCodec.encode(request)
+            structuredResponseText = "Requesting structured API information..."
+            distributedCenter.postNotificationName(
+                SpaceAPI.rpcRequest,
+                object: nil,
+                userInfo: [DesktopRenamerAPIContract.payloadKey: payload],
+                deliverImmediately: true
+            )
+        } catch {
+            structuredResponseText = "Could not encode request: \(error.localizedDescription)"
+        }
     }
 
     @objc private func handleCurrentSpaceResponse(_ notification: Notification) {
@@ -61,6 +85,29 @@ class APITester: ObservableObject {
                 result += "#\(num): \(name) [\(uuid).. ]\n"
             }
             self.responseText = result
+        }
+    }
+
+    @objc private func handleRPCResponse(_ notification: Notification) {
+        DispatchQueue.main.async {
+            guard let payload = notification.userInfo?[DesktopRenamerAPIContract.payloadKey] as? String else {
+                self.structuredResponseText = "Received empty structured response"
+                return
+            }
+
+            do {
+                let response = try SpaceAPIJSONRPCCodec.decodeResponse(payload)
+                if let error = response.error {
+                    self.structuredResponseText = "Structured API error \(error.code): \(error.message)"
+                } else if let result = response.result,
+                          let info = try? result.decode(SpaceAPIInfo.self) {
+                    self.structuredResponseText = "Structured API \(info.contractVersion), JSON-RPC \(info.jsonRPCVersion)"
+                } else {
+                    self.structuredResponseText = "Received structured API response"
+                }
+            } catch {
+                self.structuredResponseText = "Invalid structured response: \(error.localizedDescription)"
+            }
         }
     }
 }

--- a/DesktopRenamer/Services/API/APITester.swift
+++ b/DesktopRenamer/Services/API/APITester.swift
@@ -7,6 +7,7 @@ final class APITester: NSObject, ObservableObject {
     @Published var structuredResponseText: String = ""
 
     private let distributedCenter = DistributedNotificationCenter.default()
+    private var pendingStructuredRequestID: String?
 
     override init() {
         super.init()
@@ -39,7 +40,9 @@ final class APITester: NSObject, ObservableObject {
     }
 
     func sendStructuredAPIInfoRequest() {
-        let request = SpaceAPIJSONRPCRequest(id: UUID().uuidString, method: "getAPIInfo")
+        let requestID = UUID().uuidString
+        pendingStructuredRequestID = requestID
+        let request = SpaceAPIJSONRPCRequest(id: requestID, method: "getAPIInfo")
         do {
             let payload = try SpaceAPIJSONRPCCodec.encode(request)
             structuredResponseText = "Requesting structured API information..."
@@ -50,6 +53,7 @@ final class APITester: NSObject, ObservableObject {
                 deliverImmediately: true
             )
         } catch {
+            pendingStructuredRequestID = nil
             structuredResponseText = "Could not encode request: \(error.localizedDescription)"
         }
     }
@@ -97,6 +101,8 @@ final class APITester: NSObject, ObservableObject {
 
             do {
                 let response = try SpaceAPIJSONRPCCodec.decodeResponse(payload)
+                guard response.id == self.pendingStructuredRequestID else { return }
+                self.pendingStructuredRequestID = nil
                 if let error = response.error {
                     self.structuredResponseText = "Structured API error \(error.code): \(error.message)"
                 } else if let result = response.result,
@@ -106,6 +112,7 @@ final class APITester: NSObject, ObservableObject {
                     self.structuredResponseText = "Received structured API response"
                 }
             } catch {
+                self.pendingStructuredRequestID = nil
                 self.structuredResponseText = "Invalid structured response: \(error.localizedDescription)"
             }
         }

--- a/DesktopRenamer/Services/API/APIVersion.swift
+++ b/DesktopRenamer/Services/API/APIVersion.swift
@@ -5,5 +5,5 @@ import Foundation
 /// This is intentionally independent from the app's marketing/build version.
 /// Increase the major version for incompatible command or payload changes.
 enum DesktopRenamerAPIVersion {
-    static let current = "1.1.0"
+    static let current = DesktopRenamerAPIContract.version
 }

--- a/DesktopRenamer/Services/API/ScriptCommands.swift
+++ b/DesktopRenamer/Services/API/ScriptCommands.swift
@@ -163,6 +163,10 @@ class RenameCurrentSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
         guard let newName = requiredDirectString(parameter: "name") else { return nil }
+        guard runOnMain({ AppDelegate.shared.spaceManager != nil }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: RenameCurrentSpaceCommand (newName: \(newName))")
         
         // No return value needed, so standard async is fine.
@@ -244,14 +248,21 @@ class SwitchToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
         guard let spaceID = requiredDirectString(parameter: "space ID") else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
+        guard runOnMain({ manager.spaceNameDict.contains(where: { $0.id == spaceID }) }) else {
+            _ = failInvalidArgument("Invalid space ID.")
+            return nil
+        }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: SwitchToSpaceCommand (spaceID: \(spaceID))")
         
         DispatchQueue.main.async {
-            if let manager = AppDelegate.shared.spaceManager {
-                // Resolve space object by identifier.
-                if let space = manager.spaceNameDict.first(where: { $0.id == spaceID }) {
-                    manager.switchToSpace(space, forceInstant: true)
-                }
+            // Resolve space object by identifier again because Mission Control
+            // may have recreated the space between validation and dispatch.
+            if let space = manager.spaceNameDict.first(where: { $0.id == spaceID }) {
+                manager.switchToSpace(space, forceInstant: true)
             }
         }
         return nil
@@ -276,6 +287,15 @@ class RearrangeSpaceCommand: NSScriptCommand {
             return nil
         }
 
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
+        guard runOnMain({ manager.spaceNameDict.contains(where: { $0.id == sourceID }) }) else {
+            _ = failInvalidArgument("Invalid space ID.")
+            return nil
+        }
+
         DiagnosticEventLog.shared.record(
             subsystem: "AppleScript",
             level: "info",
@@ -283,8 +303,10 @@ class RearrangeSpaceCommand: NSScriptCommand {
         )
 
         DispatchQueue.main.async {
-            guard let manager = AppDelegate.shared.spaceManager,
-                  let sourceSpace = manager.spaceNameDict.first(where: { $0.id == sourceID }) else { return }
+            guard let sourceSpace = manager.spaceNameDict.first(where: { $0.id == sourceID }) else {
+                DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "warning", "Space disappeared before rearrangement: \(sourceID)")
+                return
+            }
 
             let orderedSpaces = manager.spaceNameDict
                 .filter {
@@ -292,11 +314,17 @@ class RearrangeSpaceCommand: NSScriptCommand {
                 }
                 .sorted { $0.num < $1.num }
             let orderedIDs = orderedSpaces.map(\.id)
-            guard let sourceIndex = orderedIDs.firstIndex(of: sourceID) else { return }
+            guard let sourceIndex = orderedIDs.firstIndex(of: sourceID) else {
+                DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "warning", "Space is not rearrangeable: \(sourceID)")
+                return
+            }
 
             switch rearrangementDirection {
             case .up:
-                guard sourceIndex > 0 else { return }
+                guard sourceIndex > 0 else {
+                    DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "warning", "Space is already first: \(sourceID)")
+                    return
+                }
                 SpaceRearrangementService.shared.rearrange(
                     sourceID: sourceID,
                     before: orderedIDs[sourceIndex - 1],
@@ -309,7 +337,10 @@ class RearrangeSpaceCommand: NSScriptCommand {
                     manager.refreshSpaceState()
                 }
             case .down:
-                guard sourceIndex < orderedIDs.count - 1 else { return }
+                guard sourceIndex < orderedIDs.count - 1 else {
+                    DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "warning", "Space is already last: \(sourceID)")
+                    return
+                }
                 let completion: (SpaceRearrangementService.Result) -> Void = { result in
                     if case .failure(let message) = result {
                         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "warning", message)
@@ -343,12 +374,18 @@ class RenameSpaceCommand: NSScriptCommand {
         guard isAPIEnabled() else { return nil }
         guard let spaceID = requiredDirectString(parameter: "space ID"),
               let newName = requiredArgumentString("newName") else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
+        guard runOnMain({ manager.spaceNameDict.contains(where: { $0.id == spaceID }) }) else {
+            _ = failInvalidArgument("Invalid space ID.")
+            return nil
+        }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: RenameSpaceCommand (spaceID: \(spaceID), newName: \(newName))")
         
         DispatchQueue.main.async {
-            if let manager = AppDelegate.shared.spaceManager {
-                manager.renameSpace(spaceID, to: newName)
-            }
+            manager.renameSpace(spaceID, to: newName)
         }
         return nil
     }

--- a/DesktopRenamer/Services/API/ScriptCommands.swift
+++ b/DesktopRenamer/Services/API/ScriptCommands.swift
@@ -22,6 +22,55 @@ extension NSScriptCommand {
         }
         return true
     }
+
+    @discardableResult
+    func failInvalidArgument(_ message: String) -> Bool {
+        scriptErrorNumber = -2
+        scriptErrorString = message
+        return false
+    }
+
+    @discardableResult
+    func failAppUnavailable(_ message: String = "DesktopRenamer is not ready.") -> Bool {
+        scriptErrorNumber = -3
+        scriptErrorString = message
+        return false
+    }
+
+    func requiredString(_ value: Any?, parameter: String) -> String? {
+        guard let string = value as? String, !string.isEmpty else {
+            failInvalidArgument("Parameter '\(parameter)' must be a non-empty text value.")
+            return nil
+        }
+        return string
+    }
+
+    func requiredDirectString(parameter: String) -> String? {
+        requiredString(directParameter, parameter: parameter)
+    }
+
+    func requiredArgumentString(_ parameter: String) -> String? {
+        requiredString(evaluatedArguments?[parameter], parameter: parameter)
+    }
+
+    func requiredIntegerString(_ value: Any?, parameter: String) -> String? {
+        guard let string = requiredString(value, parameter: parameter), Int(string) != nil else {
+            if scriptErrorNumber == 0 {
+                failInvalidArgument("Parameter '\(parameter)' must be an integer.")
+            }
+            return nil
+        }
+        return string
+    }
+
+    func requiredProcessIDString(_ value: Any?, parameter: String) -> String? {
+        guard let string = requiredIntegerString(value, parameter: parameter),
+              let pid = Int32(string), pid > 0 else {
+            failInvalidArgument("Parameter '\(parameter)' must be a positive process ID.")
+            return nil
+        }
+        return string
+    }
 }
 
 class ToggleMenubarCommand: NSScriptCommand {
@@ -51,7 +100,10 @@ class ToggleLabelsCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: ToggleLabelsCommand")
         guard isAPIEnabled() else { return false }
         return runOnMain {
-            guard let manager = AppDelegate.shared.statusBarController?.labelManager else { return false }
+            guard let manager = AppDelegate.shared.statusBarController?.labelManager else {
+                failAppUnavailable()
+                return false
+            }
             manager.showActiveLabels.toggle()
             manager.showPreviewLabels.toggle()
             return manager.showActiveLabels && manager.showPreviewLabels
@@ -68,6 +120,7 @@ class ToggleActiveLabelCommand: NSScriptCommand {
                 manager.showActiveLabels.toggle()
                 return manager.showActiveLabels
             }
+            failAppUnavailable()
             return false
         }
     }
@@ -82,6 +135,7 @@ class TogglePreviewLabelCommand: NSScriptCommand {
                 manager.showPreviewLabels.toggle()
                 return manager.showPreviewLabels
             }
+            failAppUnavailable()
             return false
         }
     }
@@ -99,6 +153,7 @@ class ToggleDesktopVisibilityCommand: NSScriptCommand {
                 manager.showOnDesktop.toggle()
                 return manager.showOnDesktop
             }
+            failAppUnavailable()
             return false
         }
     }
@@ -107,7 +162,7 @@ class ToggleDesktopVisibilityCommand: NSScriptCommand {
 class RenameCurrentSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let newName = self.directParameter as? String else { return nil }
+        guard let newName = requiredDirectString(parameter: "name") else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: RenameCurrentSpaceCommand (newName: \(newName))")
         
         // No return value needed, so standard async is fine.
@@ -128,7 +183,8 @@ class GetCurrentSpaceNameCommand: NSScriptCommand {
             if let manager = AppDelegate.shared.spaceManager {
                 return manager.getSpaceName(manager.currentSpaceUUID)
             }
-            return "Unknown"
+            failAppUnavailable()
+            return nil
         }
     }
 }
@@ -146,7 +202,10 @@ class GetAllSpacesCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetAllSpacesCommand")
         guard isAPIEnabled() else { return "API Disabled" }
         return runOnMain {
-            guard let manager = AppDelegate.shared.spaceManager else { return "" }
+            guard let manager = AppDelegate.shared.spaceManager else {
+                failAppUnavailable()
+                return nil
+            }
             
             // Format: "UUID|Name|DisplayID|Num"
             // Entries are grouped by display and sorted by displayID (UUID) and number.
@@ -184,7 +243,7 @@ private func getDisplayName(for uuidString: String) -> String {
 class SwitchToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let spaceID = self.directParameter as? String else { return nil }
+        guard let spaceID = requiredDirectString(parameter: "space ID") else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: SwitchToSpaceCommand (spaceID: \(spaceID))")
         
         DispatchQueue.main.async {
@@ -202,8 +261,8 @@ class SwitchToSpaceCommand: NSScriptCommand {
 class RearrangeSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let sourceID = self.directParameter as? String,
-              let direction = self.evaluatedArguments?["direction"] as? String else { return nil }
+        guard let sourceID = requiredDirectString(parameter: "space ID"),
+              let direction = requiredArgumentString("direction") else { return nil }
 
         let rearrangementDirection: DesktopRearrangementDirection
         switch direction.lowercased() {
@@ -282,9 +341,8 @@ class RearrangeSpaceCommand: NSScriptCommand {
 class RenameSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let spaceID = self.directParameter as? String,
-              let arguments = self.evaluatedArguments,
-              let newName = arguments["newName"] as? String else { return nil }
+        guard let spaceID = requiredDirectString(parameter: "space ID"),
+              let newName = requiredArgumentString("newName") else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: RenameSpaceCommand (spaceID: \(spaceID), newName: \(newName))")
         
         DispatchQueue.main.async {

--- a/DesktopRenamer/Services/API/ScriptCommands.swift
+++ b/DesktopRenamer/Services/API/ScriptCommands.swift
@@ -1,6 +1,12 @@
 import Foundation
 import AppKit
 
+enum DesktopRenamerScriptErrorCode {
+    static let apiDisabled = -1
+    static let invalidArgument = -2
+    static let appUnavailable = -3
+}
+
 // Resolves MainActor isolation for NSScriptCommand implementation.
 // Note: Explicitly enters actor context to satisfy concurrency requirements.
 func runOnMain<T>(_ block: @MainActor () -> T) -> T {
@@ -16,7 +22,7 @@ func runOnMain<T>(_ block: @MainActor () -> T) -> T {
 extension NSScriptCommand {
     func isAPIEnabled() -> Bool {
         if !SpaceManager.isAPIEnabled {
-            self.scriptErrorNumber = -1
+            self.scriptErrorNumber = DesktopRenamerScriptErrorCode.apiDisabled
             self.scriptErrorString = "API Disabled"
             return false
         }
@@ -25,14 +31,14 @@ extension NSScriptCommand {
 
     @discardableResult
     func failInvalidArgument(_ message: String) -> Bool {
-        scriptErrorNumber = -2
+        scriptErrorNumber = DesktopRenamerScriptErrorCode.invalidArgument
         scriptErrorString = message
         return false
     }
 
     @discardableResult
     func failAppUnavailable(_ message: String = "DesktopRenamer is not ready.") -> Bool {
-        scriptErrorNumber = -3
+        scriptErrorNumber = DesktopRenamerScriptErrorCode.appUnavailable
         scriptErrorString = message
         return false
     }
@@ -53,19 +59,18 @@ extension NSScriptCommand {
         requiredString(evaluatedArguments?[parameter], parameter: parameter)
     }
 
-    func requiredIntegerString(_ value: Any?, parameter: String) -> String? {
-        guard let string = requiredString(value, parameter: parameter), Int(string) != nil else {
-            if scriptErrorNumber == 0 {
-                failInvalidArgument("Parameter '\(parameter)' must be an integer.")
-            }
+    func requiredPositiveIntegerString(_ value: Any?, parameter: String) -> String? {
+        guard let string = requiredString(value, parameter: parameter) else { return nil }
+        guard let integer = Int(string), integer > 0 else {
+            failInvalidArgument("Parameter '\(parameter)' must be a positive integer.")
             return nil
         }
         return string
     }
 
     func requiredProcessIDString(_ value: Any?, parameter: String) -> String? {
-        guard let string = requiredIntegerString(value, parameter: parameter),
-              let pid = Int32(string), pid > 0 else {
+        guard let string = requiredString(value, parameter: parameter) else { return nil }
+        guard let pid = Int32(string), pid > 0 else {
             failInvalidArgument("Parameter '\(parameter)' must be a positive process ID.")
             return nil
         }
@@ -211,7 +216,6 @@ class GetAllSpacesCommand: NSScriptCommand {
                 return nil
             }
             
-            // Format: "UUID|Name|DisplayID|Num"
             // Entries are grouped by display and sorted by displayID (UUID) and number.
             let sortedSpaces = manager.spaceNameDict.sorted {
                 if $0.displayID != $1.displayID { return $0.displayID < $1.displayID }
@@ -223,7 +227,7 @@ class GetAllSpacesCommand: NSScriptCommand {
                 let name = manager.getSpaceName(space.id)
                 let displayName = getDisplayName(for: space.displayID)
 
-                // Return string split by ~ to prevent escaping issues.
+                // Keep the historical delimiter format for existing clients.
                 return "\(space.id)~\(name)~\(displayName)~\(space.num)~\(space.isFullscreen ? "1" : "0")~\(space.appPath ?? "")"
             }
             return lines.joined(separator: "\n")
@@ -282,8 +286,7 @@ class RearrangeSpaceCommand: NSScriptCommand {
         case "down":
             rearrangementDirection = .down
         default:
-            self.scriptErrorNumber = -2
-            self.scriptErrorString = "Direction must be up or down"
+            _ = failInvalidArgument("Direction must be up or down")
             return nil
         }
 

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -15,10 +15,14 @@ final class SpaceAPI {
     nonisolated static let apiToggleNotification = Notification.Name("\(apiPrefix).ReturnAPIState")
     nonisolated static let performCommand = Notification.Name("\(apiPrefix).PerformCommand")
     nonisolated static let commandResult = Notification.Name("\(apiPrefix).CommandResult")
+    nonisolated static let rpcRequest = DesktopRenamerAPIContract.rpcRequest
+    nonisolated static let rpcResponse = DesktopRenamerAPIContract.rpcResponse
+    nonisolated static let rpcEvent = DesktopRenamerAPIContract.rpcEvent
     
     // Use weak to avoid retain cycle (SpaceManager owns API, API shouldn't strongly own SpaceManager)
     private weak var spaceManager: SpaceManager?
     private var cancellables = Set<AnyCancellable>()
+    private var snapshotRevision: UInt64 = 0
 
     /// Whether the DNC listener is active (Combine pipeline has subscriptions).
     var hasActiveListeners: Bool { !cancellables.isEmpty }
@@ -39,12 +43,16 @@ final class SpaceAPI {
         dnc.addObserver(self, selector: #selector(handleSpaceListRequest), name: SpaceAPI.getSpaceList, object: nil, suspensionBehavior: .deliverImmediately)
         dnc.addObserver(self, selector: #selector(handleAPIVersionRequest), name: SpaceAPI.getAPIVersion, object: nil, suspensionBehavior: .deliverImmediately)
         dnc.addObserver(self, selector: #selector(handleCommandRequest), name: SpaceAPI.performCommand, object: nil, suspensionBehavior: .deliverImmediately)
+        dnc.addObserver(self, selector: #selector(handleRPCRequest), name: SpaceAPI.rpcRequest, object: nil, suspensionBehavior: .deliverImmediately)
         
         // Broadcast space state changes to observers.
         spaceManager.$currentSpaceUUID
             .dropFirst()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.broadcastCurrentSpace() }
+            .sink { [weak self] _ in
+                self?.broadcastCurrentSpace()
+                self?.broadcastRPCEvent(reason: "activeSpaceChanged")
+            }
             .store(in: &cancellables)
             
         spaceManager.$spaceNameDict
@@ -53,6 +61,7 @@ final class SpaceAPI {
             .sink { [weak self] _ in
                 self?.broadcastCurrentSpace()
                 self?.broadcastSpaceList()
+                self?.broadcastRPCEvent(reason: "spaceListChanged")
             }
             .store(in: &cancellables)
             
@@ -144,6 +153,71 @@ final class SpaceAPI {
         )
     }
 
+    private func broadcastRPCEvent(reason: String) {
+        guard let manager = spaceManager, SpaceManager.isAPIEnabled else { return }
+
+        snapshotRevision &+= 1
+        let snapshot = makeSpaceSnapshotPayload(manager, revision: snapshotRevision)
+        guard let snapshotValue = try? SpaceAPIJSONValue.from(snapshot) else {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "warning",
+                "Could not encode structured event snapshot."
+            )
+            return
+        }
+
+        let event = SpaceAPIJSONRPCEvent(
+            method: "stateChanged",
+            params: .object([
+                "reason": .string(reason),
+                "snapshot": snapshotValue
+            ])
+        )
+        do {
+            let payload = try SpaceAPIJSONRPCCodec.encode(event)
+            postRPCPayload(payload)
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "info",
+                "broadcastRPCEvent(reason: \(reason), revision: \(snapshotRevision))"
+            )
+        } catch {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "warning",
+                "Could not encode structured event: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func postRPCPayload(_ payload: String) {
+        DistributedNotificationCenter.default().postNotificationName(
+            SpaceAPI.rpcEvent,
+            object: nil,
+            userInfo: [DesktopRenamerAPIContract.payloadKey: payload],
+            deliverImmediately: true
+        )
+    }
+
+    private func postRPCResponse(_ response: SpaceAPIJSONRPCResponse) {
+        do {
+            let payload = try SpaceAPIJSONRPCCodec.encode(response)
+            DistributedNotificationCenter.default().postNotificationName(
+                SpaceAPI.rpcResponse,
+                object: nil,
+                userInfo: [DesktopRenamerAPIContract.payloadKey: payload],
+                deliverImmediately: true
+            )
+        } catch {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "warning",
+                "Could not post structured response: \(error.localizedDescription)"
+            )
+        }
+    }
+
     private func postCommandResult(requestID: String, result: String? = nil, error: String? = nil) {
         var userInfo: [String: Any] = [
             "requestID": requestID,
@@ -158,6 +232,99 @@ final class SpaceAPI {
             userInfo: userInfo,
             deliverImmediately: true
         )
+    }
+
+    private func executeRPCMethod(_ request: SpaceAPIJSONRPCRequest) async throws -> SpaceAPIJSONValue {
+        guard DesktopRenamerAPIContract.supportedMethods.contains(request.method) else {
+            throw SpaceAPIContractError.unsupportedMethod(request.method)
+        }
+
+        let arguments = try stringArguments(from: request.params)
+        switch request.method {
+        case "getAPIInfo":
+            guard arguments.isEmpty else {
+                throw SpaceAPIContractError.invalidParams("getAPIInfo does not accept parameters.")
+            }
+            return try SpaceAPIJSONValue.from(makeAPIInfo())
+        case "getAPIVersion":
+            guard arguments.isEmpty else {
+                throw SpaceAPIContractError.invalidParams("getAPIVersion does not accept parameters.")
+            }
+            return .string(DesktopRenamerAPIVersion.current)
+        case "getSpaceSnapshot":
+            guard arguments.isEmpty, let manager = spaceManager else {
+                if !arguments.isEmpty {
+                    throw SpaceAPIContractError.invalidParams("getSpaceSnapshot does not accept parameters.")
+                }
+                throw SpaceAPIError.appUnavailable
+            }
+            return try SpaceAPIJSONValue.from(makeSpaceSnapshotPayload(manager, revision: snapshotRevision))
+        case "getAllSpaces":
+            guard arguments.isEmpty, let manager = spaceManager else {
+                if !arguments.isEmpty {
+                    throw SpaceAPIContractError.invalidParams("getAllSpaces does not accept parameters.")
+                }
+                throw SpaceAPIError.appUnavailable
+            }
+            let spaces = makeSpaceSnapshotPayload(manager, revision: snapshotRevision).spaces
+            return try SpaceAPIJSONValue.from(["spaces": spaces])
+        case "getWindows":
+            guard arguments.isEmpty, let manager = spaceManager else {
+                if !arguments.isEmpty {
+                    throw SpaceAPIContractError.invalidParams("getWindows does not accept parameters.")
+                }
+                throw SpaceAPIError.appUnavailable
+            }
+            return try SpaceAPIJSONValue.from(makeWindowsSnapshotPayload(manager, revision: snapshotRevision))
+        case "getCurrentSpaceName":
+            guard arguments.isEmpty, let manager = spaceManager else {
+                if !arguments.isEmpty {
+                    throw SpaceAPIContractError.invalidParams("getCurrentSpaceName does not accept parameters.")
+                }
+                throw SpaceAPIError.appUnavailable
+            }
+            return .string(manager.getSpaceName(manager.currentSpaceUUID))
+        case "getCurrentSpaceID":
+            guard arguments.isEmpty else {
+                throw SpaceAPIContractError.invalidParams("getCurrentSpaceID does not accept parameters.")
+            }
+            return .array(SpaceHelper.getCurrentSpaceIDs().map(SpaceAPIJSONValue.string))
+        default:
+            let result = try await executeCommand(request.method, arguments: arguments)
+            if [
+                "toggleMenubar",
+                "toggleLauncher",
+                "toggleLabels",
+                "toggleActiveLabel",
+                "togglePreviewLabel",
+                "toggleDesktopVisibility"
+            ].contains(request.method) {
+                return .bool(result == "true")
+            }
+            return try SpaceAPIJSONValue.from(SpaceAPIOperationResult(accepted: true))
+        }
+    }
+
+    private func stringArguments(from params: SpaceAPIJSONValue?) throws -> [String: String] {
+        guard let params else { return [:] }
+        guard let object = params.objectValue else {
+            throw SpaceAPIContractError.invalidParams("Parameters must be a JSON object.")
+        }
+
+        return try object.reduce(into: [String: String]()) { result, item in
+            switch item.value {
+            case .string(let value):
+                result[item.key] = value
+            case .number(let value) where value.isFinite:
+                result[item.key] = value.rounded() == value ? String(Int(value)) : String(value)
+            case .bool(let value):
+                result[item.key] = value ? "true" : "false"
+            default:
+                throw SpaceAPIContractError.invalidParams(
+                    "Parameter '\(item.key)' must be a string, number, or Boolean."
+                )
+            }
+        }
     }
 
     private func executeCommand(_ command: String, arguments: [String: String]) async throws -> String {
@@ -464,6 +631,87 @@ final class SpaceAPI {
             }
         }
     }
+
+    @objc nonisolated private func handleRPCRequest(_ notification: Notification) {
+        let payload = notification.userInfo?[DesktopRenamerAPIContract.payloadKey] as? String
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.processRPCRequest(payload)
+        }
+    }
+
+    private func processRPCRequest(_ payload: String?) async {
+        guard let payload else {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: nil,
+                code: -32600,
+                message: "A JSON-RPC payload is required."
+            ))
+            return
+        }
+
+        let request: SpaceAPIJSONRPCRequest
+        do {
+            request = try SpaceAPIJSONRPCCodec.decodeRequest(payload)
+        } catch let error as SpaceAPIContractError {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: nil,
+                code: error.jsonRPCCode,
+                message: error.localizedDescription
+            ))
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "warning",
+                "Rejected structured request: \(error.localizedDescription)"
+            )
+            return
+        } catch {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: nil,
+                code: -32600,
+                message: "Request could not be validated."
+            ))
+            return
+        }
+
+        guard SpaceManager.isAPIEnabled else {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: request.id,
+                code: SpaceAPIError.apiDisabled.jsonRPCCode,
+                message: SpaceAPIError.apiDisabled.localizedDescription
+            ))
+            return
+        }
+
+        do {
+            let result = try await executeRPCMethod(request)
+            postRPCResponse(SpaceAPIJSONRPCResponse(id: request.id, result: result))
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceAPI",
+                level: "info",
+                "Completed structured request method=\(request.method) id=\(request.id ?? "nil")"
+            )
+        } catch let error as SpaceAPIContractError {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: request.id,
+                code: error.jsonRPCCode,
+                message: error.localizedDescription
+            ))
+        } catch let error as SpaceAPIError {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: request.id,
+                code: error.jsonRPCCode,
+                message: error.localizedDescription,
+                data: error.jsonRPCData
+            ))
+        } catch {
+            postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
+                id: request.id,
+                code: -32603,
+                message: "DesktopRenamer could not complete the request."
+            ))
+        }
+    }
 }
 
 private enum SpaceAPIError: LocalizedError {
@@ -479,6 +727,34 @@ private enum SpaceAPIError: LocalizedError {
         case .appUnavailable: return "DesktopRenamer is not ready."
         case .invalidArgument(let message), .operationFailed(let message): return message
         case .unsupportedCommand(let command): return "Unsupported SpaceAPI command: \(command)"
+        }
+    }
+}
+
+private extension SpaceAPIError {
+    var jsonRPCCode: Int {
+        switch self {
+        case .apiDisabled:
+            return -32001
+        case .appUnavailable:
+            return -32002
+        case .invalidArgument:
+            return -32602
+        case .operationFailed:
+            return -32004
+        case .unsupportedCommand:
+            return -32601
+        }
+    }
+
+    var jsonRPCData: SpaceAPIErrorData? {
+        switch self {
+        case .invalidArgument:
+            return SpaceAPIErrorData(expected: "valid command parameters")
+        case .unsupportedCommand(let command):
+            return SpaceAPIErrorData(command: command)
+        default:
+            return nil
         }
     }
 }

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -26,6 +26,9 @@ final class SpaceAPI {
 
     /// Whether the DNC listener is active (Combine pipeline has subscriptions).
     var hasActiveListeners: Bool { !cancellables.isEmpty }
+
+    /// The revision clients should use when comparing structured snapshots.
+    var currentSnapshotRevision: UInt64 { snapshotRevision }
     
     init(spaceManager: SpaceManager) {
         self.spaceManager = spaceManager

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -364,7 +364,7 @@ final class SpaceAPI {
     }
 
     private func validateRequiredParameters(_ arguments: [String: String], method: String) throws -> [String: String] {
-        for parameter in DesktopRenamerAPIContract.requiredParameters[method] ?? [] {
+        for parameter in (DesktopRenamerAPIContract.requiredParameters[method] ?? []).sorted() {
             guard let value = arguments[parameter], !value.isEmpty else {
                 throw invalidParameter(
                     method: method,
@@ -384,6 +384,9 @@ final class SpaceAPI {
     private func isInteger(_ value: String, parameter: String) -> Bool {
         if parameter == "pid", let pid = Int32(value) {
             return pid > 0
+        }
+        if parameter == "windowID", let windowID = Int(value) {
+            return windowID > 0
         }
         return Int(value) != nil
     }
@@ -723,12 +726,14 @@ final class SpaceAPI {
             return
         }
 
+        let recoverableRequestID = Self.recoverableRequestID(from: payload)
+
         let request: SpaceAPIJSONRPCRequest
         do {
             request = try SpaceAPIJSONRPCCodec.decodeRequest(payload)
         } catch let error as SpaceAPIContractError {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
-                id: nil,
+                id: recoverableRequestID,
                 code: error.jsonRPCCode,
                 message: error.localizedDescription
             ))
@@ -740,7 +745,7 @@ final class SpaceAPI {
             return
         } catch {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
-                id: nil,
+                id: recoverableRequestID,
                 code: -32600,
                 message: "Request could not be validated."
             ))
@@ -785,6 +790,18 @@ final class SpaceAPI {
                 message: "DesktopRenamer could not complete the request."
             ))
         }
+    }
+
+    private static func recoverableRequestID(from payload: String) -> String? {
+        guard payload.utf8.count <= DesktopRenamerAPIContract.maxPayloadBytes,
+              let data = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]),
+              let dictionary = object as? [String: Any],
+              let id = dictionary["id"] as? String,
+              !id.isEmpty else {
+            return nil
+        }
+        return id
     }
 }
 

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -239,7 +239,7 @@ final class SpaceAPI {
             throw SpaceAPIContractError.unsupportedMethod(request.method)
         }
 
-        let arguments = try stringArguments(from: request.params)
+        let arguments = try stringArguments(from: request.params, method: request.method)
         switch request.method {
         case "getAPIInfo":
             guard arguments.isEmpty else {
@@ -275,7 +275,8 @@ final class SpaceAPI {
                 }
                 throw SpaceAPIError.appUnavailable
             }
-            return try SpaceAPIJSONValue.from(makeWindowsSnapshotPayload(manager, revision: snapshotRevision))
+            let snapshot = await makeWindowsSnapshotPayloadAsync(manager, revision: snapshotRevision)
+            return try SpaceAPIJSONValue.from(snapshot)
         case "getCurrentSpaceName":
             guard arguments.isEmpty, let manager = spaceManager else {
                 if !arguments.isEmpty {
@@ -305,26 +306,95 @@ final class SpaceAPI {
         }
     }
 
-    private func stringArguments(from params: SpaceAPIJSONValue?) throws -> [String: String] {
-        guard let params else { return [:] }
+    private func stringArguments(from params: SpaceAPIJSONValue?, method: String) throws -> [String: String] {
+        guard let params else {
+            return try validateRequiredParameters([:], method: method)
+        }
         guard let object = params.objectValue else {
             throw SpaceAPIContractError.invalidParams("Parameters must be a JSON object.")
         }
 
-        return try object.reduce(into: [String: String]()) { result, item in
+        let allowedParameters = DesktopRenamerAPIContract.allowedParameters[method] ?? []
+        if let unknownParameter = object.keys.sorted().first(where: { !allowedParameters.contains($0) }) {
+            throw invalidParameter(
+                method: method,
+                name: unknownParameter,
+                expected: "a supported parameter",
+                message: "Parameter '\(unknownParameter)' is not supported for \(method)."
+            )
+        }
+
+        let arguments = try object.reduce(into: [String: String]()) { result, item in
+            let expected = expectedParameterType(for: item.key)
             switch item.value {
             case .string(let value):
+                if expected == "integer", !isInteger(value, parameter: item.key) {
+                    throw invalidParameter(
+                        method: method,
+                        name: item.key,
+                        expected: expected,
+                        message: "Parameter '\(item.key)' must be an integer."
+                    )
+                }
                 result[item.key] = value
-            case .number(let value) where value.isFinite:
-                result[item.key] = value.rounded() == value ? String(Int(value)) : String(value)
-            case .bool(let value):
-                result[item.key] = value ? "true" : "false"
+            case .number(let value) where value.isFinite && value.rounded() == value && expected == "integer":
+                guard let integer = Int(exactly: value) else {
+                    throw invalidParameter(
+                        method: method,
+                        name: item.key,
+                        expected: expected,
+                        message: "Parameter '\(item.key)' is outside the supported integer range."
+                    )
+                }
+                result[item.key] = String(integer)
             default:
-                throw SpaceAPIContractError.invalidParams(
-                    "Parameter '\(item.key)' must be a string, number, or Boolean."
+                throw invalidParameter(
+                    method: method,
+                    name: item.key,
+                    expected: expected,
+                    message: "Parameter '\(item.key)' must be an \(expected)."
                 )
             }
         }
+
+        return try validateRequiredParameters(arguments, method: method)
+    }
+
+    private func validateRequiredParameters(_ arguments: [String: String], method: String) throws -> [String: String] {
+        for parameter in DesktopRenamerAPIContract.requiredParameters[method] ?? [] {
+            guard let value = arguments[parameter], !value.isEmpty else {
+                throw invalidParameter(
+                    method: method,
+                    name: parameter,
+                    expected: expectedParameterType(for: parameter),
+                    message: "Missing required parameter '\(parameter)'."
+                )
+            }
+        }
+        return arguments
+    }
+
+    private func expectedParameterType(for parameter: String) -> String {
+        ["windowID", "pid"].contains(parameter) ? "integer" : "string"
+    }
+
+    private func isInteger(_ value: String, parameter: String) -> Bool {
+        if parameter == "pid", let pid = Int32(value) {
+            return pid > 0
+        }
+        return Int(value) != nil
+    }
+
+    private func invalidParameter(
+        method: String,
+        name: String,
+        expected: String,
+        message: String
+    ) -> SpaceAPIContractError {
+        .invalidParamsWithData(
+            message,
+            SpaceAPIErrorData(parameter: name, expected: expected, command: method)
+        )
     }
 
     private func executeCommand(_ command: String, arguments: [String: String]) async throws -> String {
@@ -695,7 +765,8 @@ final class SpaceAPI {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: request.id,
                 code: error.jsonRPCCode,
-                message: error.localizedDescription
+                message: error.localizedDescription,
+                data: error.jsonRPCData
             ))
         } catch let error as SpaceAPIError {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -278,169 +278,42 @@ final class SpaceAPI {
     }
 
     private func executeRPCMethod(_ request: SpaceAPIJSONRPCRequest) async throws -> SpaceAPIJSONValue {
-        guard DesktopRenamerAPIContract.supportedMethods.contains(request.method) else {
+        guard let definition = DesktopRenamerAPIContract.definition(for: request.method) else {
             throw SpaceAPIContractError.unsupportedMethod(request.method)
         }
 
-        let arguments = try stringArguments(from: request.params, method: request.method)
+        let arguments = try SpaceAPIArgumentValidator.stringArguments(from: request.params, method: request.method)
         switch request.method {
         case "getAPIInfo":
-            guard arguments.isEmpty else {
-                throw SpaceAPIContractError.invalidParams("getAPIInfo does not accept parameters.")
-            }
             return try SpaceAPIJSONValue.from(makeAPIInfo())
         case "getAPIVersion":
-            guard arguments.isEmpty else {
-                throw SpaceAPIContractError.invalidParams("getAPIVersion does not accept parameters.")
-            }
             return .string(DesktopRenamerAPIVersion.current)
         case "getSpaceSnapshot":
-            guard arguments.isEmpty, let manager = spaceManager else {
-                if !arguments.isEmpty {
-                    throw SpaceAPIContractError.invalidParams("getSpaceSnapshot does not accept parameters.")
-                }
-                throw SpaceAPIError.appUnavailable
-            }
+            guard let manager = spaceManager else { throw SpaceAPIError.appUnavailable }
             return try SpaceAPIJSONValue.from(makeSpaceSnapshotPayload(manager, revision: snapshotRevision))
         case "getAllSpaces":
-            guard arguments.isEmpty, let manager = spaceManager else {
-                if !arguments.isEmpty {
-                    throw SpaceAPIContractError.invalidParams("getAllSpaces does not accept parameters.")
-                }
-                throw SpaceAPIError.appUnavailable
-            }
-            let spaces = makeSpaceSnapshotPayload(manager, revision: snapshotRevision).spaces
-            return try SpaceAPIJSONValue.from(["spaces": spaces])
+            guard let manager = spaceManager else { throw SpaceAPIError.appUnavailable }
+            let spaces = makeSpaceRecords(manager)
+            return try SpaceAPIJSONValue.from(spaces)
         case "getWindows":
-            guard arguments.isEmpty, let manager = spaceManager else {
-                if !arguments.isEmpty {
-                    throw SpaceAPIContractError.invalidParams("getWindows does not accept parameters.")
-                }
-                throw SpaceAPIError.appUnavailable
-            }
+            guard let manager = spaceManager else { throw SpaceAPIError.appUnavailable }
             let snapshot = await makeWindowsSnapshotPayloadAsync(manager, revision: snapshotRevision)
             return try SpaceAPIJSONValue.from(snapshot)
         case "getCurrentSpaceName":
-            guard arguments.isEmpty, let manager = spaceManager else {
-                if !arguments.isEmpty {
-                    throw SpaceAPIContractError.invalidParams("getCurrentSpaceName does not accept parameters.")
-                }
-                throw SpaceAPIError.appUnavailable
-            }
+            guard let manager = spaceManager else { throw SpaceAPIError.appUnavailable }
             return .string(manager.getSpaceName(manager.currentSpaceUUID))
         case "getCurrentSpaceID":
-            guard arguments.isEmpty else {
-                throw SpaceAPIContractError.invalidParams("getCurrentSpaceID does not accept parameters.")
-            }
             return .array(SpaceHelper.getCurrentSpaceIDs().map(SpaceAPIJSONValue.string))
         default:
             let result = try await executeCommand(request.method, arguments: arguments)
-            if [
-                "toggleMenubar",
-                "toggleLauncher",
-                "toggleLabels",
-                "toggleActiveLabel",
-                "togglePreviewLabel",
-                "toggleDesktopVisibility"
-            ].contains(request.method) {
+            if definition.resultKind == .boolean {
+                guard result == "true" || result == "false" else {
+                    throw SpaceAPIError.operationFailed("The command returned an invalid Boolean result.")
+                }
                 return .bool(result == "true")
             }
             return try SpaceAPIJSONValue.from(SpaceAPIOperationResult(accepted: true))
         }
-    }
-
-    private func stringArguments(from params: SpaceAPIJSONValue?, method: String) throws -> [String: String] {
-        guard let params else {
-            return try validateRequiredParameters([:], method: method)
-        }
-        guard let object = params.objectValue else {
-            throw SpaceAPIContractError.invalidParams("Parameters must be a JSON object.")
-        }
-
-        let allowedParameters = DesktopRenamerAPIContract.allowedParameters[method] ?? []
-        if let unknownParameter = object.keys.sorted().first(where: { !allowedParameters.contains($0) }) {
-            throw invalidParameter(
-                method: method,
-                name: unknownParameter,
-                expected: "a supported parameter",
-                message: "Parameter '\(unknownParameter)' is not supported for \(method)."
-            )
-        }
-
-        let arguments = try object.reduce(into: [String: String]()) { result, item in
-            let expected = expectedParameterType(for: item.key)
-            switch item.value {
-            case .string(let value):
-                if expected == "integer", !isInteger(value, parameter: item.key) {
-                    throw invalidParameter(
-                        method: method,
-                        name: item.key,
-                        expected: expected,
-                        message: "Parameter '\(item.key)' must be an integer."
-                    )
-                }
-                result[item.key] = value
-            case .number(let value) where value.isFinite && value.rounded() == value && expected == "integer":
-                guard let integer = Int(exactly: value) else {
-                    throw invalidParameter(
-                        method: method,
-                        name: item.key,
-                        expected: expected,
-                        message: "Parameter '\(item.key)' is outside the supported integer range."
-                    )
-                }
-                result[item.key] = String(integer)
-            default:
-                throw invalidParameter(
-                    method: method,
-                    name: item.key,
-                    expected: expected,
-                    message: "Parameter '\(item.key)' must be an \(expected)."
-                )
-            }
-        }
-
-        return try validateRequiredParameters(arguments, method: method)
-    }
-
-    private func validateRequiredParameters(_ arguments: [String: String], method: String) throws -> [String: String] {
-        for parameter in (DesktopRenamerAPIContract.requiredParameters[method] ?? []).sorted() {
-            guard let value = arguments[parameter], !value.isEmpty else {
-                throw invalidParameter(
-                    method: method,
-                    name: parameter,
-                    expected: expectedParameterType(for: parameter),
-                    message: "Missing required parameter '\(parameter)'."
-                )
-            }
-        }
-        return arguments
-    }
-
-    private func expectedParameterType(for parameter: String) -> String {
-        ["windowID", "pid"].contains(parameter) ? "integer" : "string"
-    }
-
-    private func isInteger(_ value: String, parameter: String) -> Bool {
-        if parameter == "pid", let pid = Int32(value) {
-            return pid > 0
-        }
-        if parameter == "windowID", let windowID = Int(value) {
-            return windowID > 0
-        }
-        return Int(value) != nil
-    }
-
-    private func invalidParameter(
-        method: String,
-        name: String,
-        expected: String,
-        message: String
-    ) -> SpaceAPIContractError {
-        .invalidParamsWithData(
-            message,
-            SpaceAPIErrorData(parameter: name, expected: expected, command: method)
-        )
     }
 
     private func executeCommand(_ command: String, arguments: [String: String]) async throws -> String {
@@ -498,7 +371,10 @@ final class SpaceAPI {
             manager.moveActiveWindowToSpace(id: spaceID)
             return ""
         case "reloadSpaceLabels":
-            AppDelegate.shared.statusBarController?.labelManager.reloadAllWindows()
+            guard let labelManager = AppDelegate.shared.statusBarController?.labelManager else {
+                throw SpaceAPIError.appUnavailable
+            }
+            labelManager.reloadAllWindows()
             return ""
         case "toggleMenubar":
             StatusBarController.toggleStatusBar()
@@ -581,13 +457,9 @@ final class SpaceAPI {
     }
 
     private func executeWindowAction(windowID: Int, pid: Int32, action: String, manager: SpaceManager) async throws {
-        if let spaceID = SpaceHelper.getWindowSpaceID(id: windowID),
-           manager.currentSpaceUUID != spaceID,
-           let space = manager.spaceNameDict.first(where: { $0.id == spaceID }) {
-            manager.switchToSpace(space, forceInstant: true)
-            try await Task.sleep(nanoseconds: 600_000_000)
-        }
-
+        // Quitting an app is process-scoped and does not require its window to
+        // be made frontmost. Avoid moving the user's desktop just to terminate
+        // an application in another space.
         if action == "quit" {
             guard let app = NSRunningApplication(processIdentifier: pid) else {
                 throw SpaceAPIError.operationFailed("Application is no longer running.")
@@ -595,6 +467,14 @@ final class SpaceAPI {
             app.terminate()
             return
         }
+
+        if let spaceID = SpaceHelper.getWindowSpaceID(id: windowID),
+           manager.currentSpaceUUID != spaceID,
+           let space = manager.spaceNameDict.first(where: { $0.id == spaceID }) {
+            manager.switchToSpace(space, forceInstant: true)
+            try await Task.sleep(nanoseconds: 600_000_000)
+        }
+
         if action == "hide" {
             NSRunningApplication(processIdentifier: pid)?.hide()
             return
@@ -722,15 +602,23 @@ final class SpaceAPI {
 
     @objc nonisolated private func handleCommandRequest(_ notification: Notification) {
         let userInfo = notification.userInfo ?? [:]
-        let requestID = userInfo["requestID"] as? String ?? UUID().uuidString
+        let requestID = (userInfo["requestID"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString
         let command = userInfo["command"] as? String ?? ""
-        let arguments: [String: String]
-        if let argumentsJSON = userInfo["argumentsJSON"] as? String,
-           let data = argumentsJSON.data(using: .utf8),
-           let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
-            arguments = decoded
-        } else {
-            arguments = userInfo["arguments"] as? [String: String] ?? [:]
+        var arguments: [String: String] = [:]
+        var argumentError: String?
+        if let argumentsJSON = userInfo["argumentsJSON"] as? String {
+            if let data = argumentsJSON.data(using: .utf8),
+               let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
+                arguments = decoded
+            } else {
+                argumentError = "Arguments must be a JSON object containing only string values."
+            }
+        } else if let rawArguments = userInfo["arguments"] {
+            if let decoded = rawArguments as? [String: String] {
+                arguments = decoded
+            } else {
+                argumentError = "Arguments must be a dictionary containing only string values."
+            }
         }
 
         Task { @MainActor [weak self] in
@@ -739,8 +627,16 @@ final class SpaceAPI {
                 self.postCommandResult(requestID: requestID, error: SpaceAPIError.apiDisabled.localizedDescription)
                 return
             }
+            if let argumentError {
+                self.postCommandResult(requestID: requestID, error: argumentError)
+                return
+            }
             do {
-                let result = try await self.executeCommand(command, arguments: arguments)
+                let validatedArguments = try SpaceAPIArgumentValidator.stringArguments(
+                    from: .object(arguments.mapValues { .string($0) }),
+                    method: command
+                )
+                let result = try await self.executeCommand(command, arguments: validatedArguments)
                 self.postCommandResult(requestID: requestID, result: result)
             } catch {
                 self.postCommandResult(requestID: requestID, error: error.localizedDescription)
@@ -760,7 +656,7 @@ final class SpaceAPI {
         guard let payload else {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: nil,
-                code: -32600,
+                code: SpaceAPIJSONRPCCode.invalidRequest,
                 message: "A JSON-RPC payload is required."
             ))
             return
@@ -775,7 +671,8 @@ final class SpaceAPI {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: recoverableRequestID,
                 code: error.jsonRPCCode,
-                message: error.localizedDescription
+                message: error.localizedDescription,
+                data: error.jsonRPCData
             ))
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceAPI",
@@ -786,7 +683,7 @@ final class SpaceAPI {
         } catch {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: recoverableRequestID,
-                code: -32600,
+                code: SpaceAPIJSONRPCCode.invalidRequest,
                 message: "Request could not be validated."
             ))
             return
@@ -807,26 +704,26 @@ final class SpaceAPI {
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceAPI",
                 level: "info",
-                "Completed structured request method=\(request.method) id=\(request.id ?? "nil")"
+                "Completed structured request method=\(request.method) id=\(request.id)"
             )
         } catch let error as SpaceAPIContractError {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: request.id,
                 code: error.jsonRPCCode,
                 message: error.localizedDescription,
-                data: error.jsonRPCData
+                data: error.jsonRPCData(command: request.method)
             ))
         } catch let error as SpaceAPIError {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: request.id,
                 code: error.jsonRPCCode,
                 message: error.localizedDescription,
-                data: error.jsonRPCData
+                data: error.jsonRPCData(command: request.method)
             ))
         } catch {
             postRPCResponse(SpaceAPIJSONRPCCodec.errorResponse(
                 id: request.id,
-                code: -32603,
+                code: SpaceAPIJSONRPCCode.internalError,
                 message: "DesktopRenamer could not complete the request."
             ))
         }
@@ -866,22 +763,24 @@ private extension SpaceAPIError {
     var jsonRPCCode: Int {
         switch self {
         case .apiDisabled:
-            return -32001
+            return SpaceAPIJSONRPCCode.apiDisabled
         case .appUnavailable:
-            return -32002
+            return SpaceAPIJSONRPCCode.appUnavailable
         case .invalidArgument:
-            return -32602
+            return SpaceAPIJSONRPCCode.invalidParams
         case .operationFailed:
-            return -32004
+            return SpaceAPIJSONRPCCode.operationFailed
         case .unsupportedCommand:
-            return -32601
+            return SpaceAPIJSONRPCCode.methodNotFound
         }
     }
 
-    var jsonRPCData: SpaceAPIErrorData? {
+    func jsonRPCData(command: String? = nil) -> SpaceAPIErrorData? {
         switch self {
         case .invalidArgument:
-            return SpaceAPIErrorData(expected: "valid command parameters")
+            return SpaceAPIErrorData(expected: "valid command parameters", command: command)
+        case .operationFailed:
+            return command.map { SpaceAPIErrorData(command: $0) }
         case .unsupportedCommand(let command):
             return SpaceAPIErrorData(command: command)
         default:

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -204,21 +204,40 @@ final class SpaceAPI {
     }
 
     private func postRPCResponse(_ response: SpaceAPIJSONRPCResponse) {
+        let payload: String
         do {
-            let payload = try SpaceAPIJSONRPCCodec.encode(response)
-            DistributedNotificationCenter.default().postNotificationName(
-                SpaceAPI.rpcResponse,
-                object: nil,
-                userInfo: [DesktopRenamerAPIContract.payloadKey: payload],
-                deliverImmediately: true
+            payload = try SpaceAPIJSONRPCCodec.encode(response)
+        } catch let error as SpaceAPIContractError {
+            let fallback = SpaceAPIJSONRPCCodec.errorResponse(
+                id: response.id,
+                code: error.jsonRPCCode,
+                message: error.localizedDescription,
+                data: error.jsonRPCData
             )
+            guard let fallbackPayload = try? SpaceAPIJSONRPCCodec.encode(fallback) else {
+                DiagnosticEventLog.shared.record(
+                    subsystem: "SpaceAPI",
+                    level: "warning",
+                    "Could not encode structured error response: \(error.localizedDescription)"
+                )
+                return
+            }
+            payload = fallbackPayload
         } catch {
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceAPI",
                 level: "warning",
-                "Could not post structured response: \(error.localizedDescription)"
+                "Could not encode structured response: \(error.localizedDescription)"
             )
+            return
         }
+
+        DistributedNotificationCenter.default().postNotificationName(
+            SpaceAPI.rpcResponse,
+            object: nil,
+            userInfo: [DesktopRenamerAPIContract.payloadKey: payload],
+            deliverImmediately: true
+        )
     }
 
     private func postCommandResult(requestID: String, result: String? = nil, error: String? = nil) {

--- a/DesktopRenamer/Services/API/SpaceAPI.swift
+++ b/DesktopRenamer/Services/API/SpaceAPI.swift
@@ -23,9 +23,10 @@ final class SpaceAPI {
     private weak var spaceManager: SpaceManager?
     private var cancellables = Set<AnyCancellable>()
     private var snapshotRevision: UInt64 = 0
+    private var rpcListenerInstalled = false
 
     /// Whether the DNC listener is active (Combine pipeline has subscriptions).
-    var hasActiveListeners: Bool { !cancellables.isEmpty }
+    var hasActiveListeners: Bool { rpcListenerInstalled || !cancellables.isEmpty }
 
     /// The revision clients should use when comparing structured snapshots.
     var currentSnapshotRevision: UInt64 { snapshotRevision }
@@ -36,8 +37,13 @@ final class SpaceAPI {
     
     func setupListener() {
         DiagnosticEventLog.shared.record(subsystem: "SpaceAPI", level: "info", "setupListener")
-        guard let spaceManager = spaceManager else { return }
         removeListener()
+        installRPCListener()
+
+        guard SpaceManager.isAPIEnabled, let spaceManager = spaceManager else {
+            print("SpaceAPI: Structured listener Started (API disabled)")
+            return
+        }
         
         let dnc = DistributedNotificationCenter.default()
         
@@ -46,7 +52,6 @@ final class SpaceAPI {
         dnc.addObserver(self, selector: #selector(handleSpaceListRequest), name: SpaceAPI.getSpaceList, object: nil, suspensionBehavior: .deliverImmediately)
         dnc.addObserver(self, selector: #selector(handleAPIVersionRequest), name: SpaceAPI.getAPIVersion, object: nil, suspensionBehavior: .deliverImmediately)
         dnc.addObserver(self, selector: #selector(handleCommandRequest), name: SpaceAPI.performCommand, object: nil, suspensionBehavior: .deliverImmediately)
-        dnc.addObserver(self, selector: #selector(handleRPCRequest), name: SpaceAPI.rpcRequest, object: nil, suspensionBehavior: .deliverImmediately)
         
         // Broadcast space state changes to observers.
         spaceManager.$currentSpaceUUID
@@ -74,8 +79,24 @@ final class SpaceAPI {
     func removeListener() {
         DiagnosticEventLog.shared.record(subsystem: "SpaceAPI", level: "info", "removeListener")
         DistributedNotificationCenter.default().removeObserver(self)
+        rpcListenerInstalled = false
         cancellables.removeAll()
+        if !SpaceManager.isAPIEnabled {
+            installRPCListener()
+        }
         print("SpaceAPI: Listener Stopped")
+    }
+
+    private func installRPCListener() {
+        guard !rpcListenerInstalled else { return }
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(handleRPCRequest),
+            name: SpaceAPI.rpcRequest,
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
+        rpcListenerInstalled = true
     }
     
     // API status management.

--- a/DesktopRenamer/Services/API/SpaceAPILegacyFormat.swift
+++ b/DesktopRenamer/Services/API/SpaceAPILegacyFormat.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Keeps the historical delimiter-based output stable for existing clients.
+enum SpaceAPILegacyFormatter {
+    static func spaceLine(
+        id: String,
+        name: String,
+        displayName: String,
+        number: Int,
+        isFullscreen: Bool,
+        appPath: String?
+    ) -> String {
+        ">\(id)~\(name)~\(displayName)~\(number)~\(isFullscreen ? "1" : "0")~\(appPath ?? "")\n"
+    }
+
+    static func windowLine(
+        id: Int,
+        pid: Int32,
+        ownerName: String,
+        appPath: String?,
+        title: String?,
+        isMinimized: Bool,
+        isHidden: Bool
+    ) -> String {
+        "  \(id)|\(pid)|\(ownerName)|\(appPath ?? "")|\(title ?? "")|\(isMinimized ? "1" : "0")|\(isHidden ? "1" : "0")\n"
+    }
+}

--- a/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
+++ b/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
@@ -27,6 +27,23 @@ extension SpaceAPI {
         )
     }
 
+    func makeWindowsSnapshotPayloadAsync(_ manager: SpaceManager, revision: UInt64) async -> SpaceAPIWindowsSnapshot {
+        let spaces = manager.spaceNameDict
+        let spaceRecords = makeSpaceRecords(manager)
+        let timestamp = Self.apiTimestamp()
+        let windows = await Task.detached(priority: .userInitiated) {
+            SpaceHelper.getWindowRecordsForAllSpaces(spaces: spaces)
+        }.value
+
+        return SpaceAPIWindowsSnapshot(
+            apiVersion: DesktopRenamerAPIVersion.current,
+            revision: revision,
+            timestamp: timestamp,
+            spaces: spaceRecords,
+            windows: windows
+        )
+    }
+
     func makeWindowsSnapshot(_ manager: SpaceManager, revision: UInt64) throws -> String {
         try encodeJSON(makeWindowsSnapshotPayload(manager, revision: revision))
     }
@@ -37,7 +54,9 @@ extension SpaceAPI {
             jsonRPCVersion: DesktopRenamerAPIContract.jsonRPCVersion,
             supportedMethods: DesktopRenamerAPIContract.supportedMethods,
             legacyNotifications: true,
+            legacyCompatibility: "supported",
             eventNotifications: true,
+            eventCapabilities: ["stateChanged"],
             maxPayloadBytes: DesktopRenamerAPIContract.maxPayloadBytes
         )
     }

--- a/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
+++ b/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
@@ -16,6 +16,7 @@ extension SpaceAPI {
     /// Returns the historical snapshot shape used by the legacy command channel.
     /// Structured clients should use makeSpaceSnapshotPayload instead.
     func makeSpaceSnapshot(_ manager: SpaceManager) throws -> String {
+        let displayNames = displayNamesByID()
         let spaces = manager.spaceNameDict
             .sorted {
                 if $0.displayID != $1.displayID {
@@ -28,7 +29,7 @@ extension SpaceAPI {
                     "id": space.id,
                     "name": manager.getSpaceName(space.id),
                     "displayID": space.displayID,
-                    "displayName": displayName(for: space.displayID),
+                    "displayName": displayName(for: space.displayID, using: displayNames),
                     "number": space.num,
                     "isFullscreen": space.isFullscreen
                 ]
@@ -99,7 +100,8 @@ extension SpaceAPI {
     }
 
     func makeSpaceRecords(_ manager: SpaceManager) -> [SpaceAPISpace] {
-        manager.spaceNameDict
+        let displayNames = displayNamesByID()
+        return manager.spaceNameDict
             .sorted {
                 if $0.displayID != $1.displayID {
                     return $0.displayID.localizedStandardCompare($1.displayID) == .orderedAscending
@@ -111,7 +113,7 @@ extension SpaceAPI {
                     id: space.id,
                     name: manager.getSpaceName(space.id),
                     displayID: space.displayID,
-                    displayName: displayName(for: space.displayID),
+                    displayName: displayName(for: space.displayID, using: displayNames),
                     number: space.num,
                     isFullscreen: space.isFullscreen,
                     appName: space.appName,
@@ -121,18 +123,25 @@ extension SpaceAPI {
             }
     }
 
-    private func displayName(for displayID: String) -> String {
-        for screen in NSScreen.screens {
+    private func displayNamesByID() -> [String: String] {
+        NSScreen.screens.reduce(into: [String: String]()) { names, screen in
             guard let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber,
                   let uuid = CGDisplayCreateUUIDFromDisplayID(screenNumber.uint32Value)?.takeRetainedValue(),
                   let uuidString = CFUUIDCreateString(nil, uuid) as String? else {
-                continue
+                return
             }
-            if uuidString.caseInsensitiveCompare(displayID) == .orderedSame {
-                return screen.localizedName
-            }
+            names[uuidString.uppercased()] = screen.localizedName
         }
-        return displayID == "Main" ? "Main Display" : "Display"
+    }
+
+    private func displayName(for displayID: String, using displayNames: [String: String]) -> String {
+        if let name = displayNames[displayID.uppercased()] {
+            return name
+        }
+        if displayID.caseInsensitiveCompare("Main") == .orderedSame {
+            return "Main Display"
+        }
+        return "Display"
     }
 
     private func encodeJSON<T: Encodable>(_ value: T) throws -> String {

--- a/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
+++ b/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
@@ -1,42 +1,68 @@
-import Foundation
 import AppKit
+import Foundation
 
 extension SpaceAPI {
-    func makeSpaceSnapshot(_ manager: SpaceManager) throws -> String {
-        let spaces = manager.spaceNameDict.sorted {
-            if $0.displayID != $1.displayID {
-                return $0.displayID.localizedStandardCompare($1.displayID) == .orderedAscending
+    func makeSpaceSnapshotPayload(_ manager: SpaceManager, revision: UInt64) -> SpaceAPISnapshot {
+        SpaceAPISnapshot(
+            apiVersion: DesktopRenamerAPIVersion.current,
+            revision: revision,
+            timestamp: Self.apiTimestamp(),
+            currentSpaceIDs: SpaceHelper.getCurrentSpaceIDs(),
+            currentSpaceName: manager.getSpaceName(manager.currentSpaceUUID),
+            spaces: makeSpaceRecords(manager)
+        )
+    }
+
+    func makeSpaceSnapshot(_ manager: SpaceManager, revision: UInt64 = 0) throws -> String {
+        try encodeJSON(makeSpaceSnapshotPayload(manager, revision: revision))
+    }
+
+    func makeWindowsSnapshotPayload(_ manager: SpaceManager, revision: UInt64) -> SpaceAPIWindowsSnapshot {
+        SpaceAPIWindowsSnapshot(
+            apiVersion: DesktopRenamerAPIVersion.current,
+            revision: revision,
+            timestamp: Self.apiTimestamp(),
+            spaces: makeSpaceRecords(manager),
+            windows: SpaceHelper.getWindowRecordsForAllSpaces(spaces: manager.spaceNameDict)
+        )
+    }
+
+    func makeWindowsSnapshot(_ manager: SpaceManager, revision: UInt64) throws -> String {
+        try encodeJSON(makeWindowsSnapshotPayload(manager, revision: revision))
+    }
+
+    func makeAPIInfo() -> SpaceAPIInfo {
+        SpaceAPIInfo(
+            contractVersion: DesktopRenamerAPIVersion.current,
+            jsonRPCVersion: DesktopRenamerAPIContract.jsonRPCVersion,
+            supportedMethods: DesktopRenamerAPIContract.supportedMethods,
+            legacyNotifications: true,
+            eventNotifications: true,
+            maxPayloadBytes: DesktopRenamerAPIContract.maxPayloadBytes
+        )
+    }
+
+    private func makeSpaceRecords(_ manager: SpaceManager) -> [SpaceAPISpace] {
+        manager.spaceNameDict
+            .sorted {
+                if $0.displayID != $1.displayID {
+                    return $0.displayID.localizedStandardCompare($1.displayID) == .orderedAscending
+                }
+                return $0.num < $1.num
             }
-            return $0.num < $1.num
-        }.map { space in
-            var result: [String: Any] = [
-                "id": space.id,
-                "name": manager.getSpaceName(space.id),
-                "displayID": space.displayID,
-                "displayName": displayName(for: space.displayID),
-                "number": space.num,
-                "isFullscreen": space.isFullscreen
-            ]
-            if let appPath = space.appPath {
-                result["appPath"] = appPath
+            .map { space in
+                SpaceAPISpace(
+                    id: space.id,
+                    name: manager.getSpaceName(space.id),
+                    displayID: space.displayID,
+                    displayName: displayName(for: space.displayID),
+                    number: space.num,
+                    isFullscreen: space.isFullscreen,
+                    appName: space.appName,
+                    appPath: space.appPath,
+                    globalShortcutNumber: space.globalShortcutNum
+                )
             }
-            return result
-        }
-        let snapshot: [String: Any] = [
-            "apiVersion": DesktopRenamerAPIVersion.current,
-            "currentSpaceIDs": SpaceHelper.getCurrentSpaceIDs(),
-            "currentSpaceName": manager.getSpaceName(manager.currentSpaceUUID),
-            "spaces": spaces
-        ]
-        guard JSONSerialization.isValidJSONObject(snapshot) else {
-            throw NSError(
-                domain: "DesktopRenamer.SpaceAPI",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Could not encode space snapshot."]
-            )
-        }
-        let data = try JSONSerialization.data(withJSONObject: snapshot)
-        return String(decoding: data, as: UTF8.self)
     }
 
     private func displayName(for displayID: String) -> String {
@@ -51,5 +77,19 @@ extension SpaceAPI {
             }
         }
         return displayID == "Main" ? "Main Display" : "Display"
+    }
+
+    private func encodeJSON<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        guard data.count <= DesktopRenamerAPIContract.maxPayloadBytes else {
+            throw SpaceAPIContractError.payloadTooLarge
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func apiTimestamp() -> String {
+        ISO8601DateFormatter().string(from: Date())
     }
 }

--- a/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
+++ b/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
@@ -13,8 +13,45 @@ extension SpaceAPI {
         )
     }
 
-    func makeSpaceSnapshot(_ manager: SpaceManager, revision: UInt64 = 0) throws -> String {
-        try encodeJSON(makeSpaceSnapshotPayload(manager, revision: revision))
+    /// Returns the historical snapshot shape used by the legacy command channel.
+    /// Structured clients should use makeSpaceSnapshotPayload instead.
+    func makeSpaceSnapshot(_ manager: SpaceManager) throws -> String {
+        let spaces = manager.spaceNameDict
+            .sorted {
+                if $0.displayID != $1.displayID {
+                    return $0.displayID.localizedStandardCompare($1.displayID) == .orderedAscending
+                }
+                return $0.num < $1.num
+            }
+            .map { space -> [String: Any] in
+                var record: [String: Any] = [
+                    "id": space.id,
+                    "name": manager.getSpaceName(space.id),
+                    "displayID": space.displayID,
+                    "displayName": displayName(for: space.displayID),
+                    "number": space.num,
+                    "isFullscreen": space.isFullscreen
+                ]
+                if let appPath = space.appPath {
+                    record["appPath"] = appPath
+                }
+                return record
+            }
+        let snapshot: [String: Any] = [
+            "apiVersion": DesktopRenamerAPIVersion.current,
+            "currentSpaceIDs": SpaceHelper.getCurrentSpaceIDs(),
+            "currentSpaceName": manager.getSpaceName(manager.currentSpaceUUID),
+            "spaces": spaces
+        ]
+        guard JSONSerialization.isValidJSONObject(snapshot) else {
+            throw NSError(
+                domain: "DesktopRenamer.SpaceAPI",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not encode space snapshot."]
+            )
+        }
+        let data = try JSONSerialization.data(withJSONObject: snapshot)
+        return String(decoding: data, as: UTF8.self)
     }
 
     func makeWindowsSnapshotPayload(_ manager: SpaceManager, revision: UInt64) -> SpaceAPIWindowsSnapshot {

--- a/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
+++ b/DesktopRenamer/Services/API/SpaceAPISnapshot.swift
@@ -42,7 +42,7 @@ extension SpaceAPI {
         )
     }
 
-    private func makeSpaceRecords(_ manager: SpaceManager) -> [SpaceAPISpace] {
+    func makeSpaceRecords(_ manager: SpaceManager) -> [SpaceAPISpace] {
         manager.spaceNameDict
             .sorted {
                 if $0.displayID != $1.displayID {

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -1,0 +1,137 @@
+import AppKit
+import Foundation
+
+private func scriptSpaceRecord(_ space: SpaceAPISpace) -> [String: Any] {
+    var record: [String: Any] = [
+        "id": space.id,
+        "name": space.name,
+        "displayID": space.displayID,
+        "displayName": space.displayName,
+        "number": space.number,
+        "isFullscreen": space.isFullscreen
+    ]
+    if let appName = space.appName {
+        record["appName"] = appName
+    }
+    if let appPath = space.appPath {
+        record["appPath"] = appPath
+    }
+    if let globalShortcutNumber = space.globalShortcutNumber {
+        record["globalShortcutNumber"] = globalShortcutNumber
+    }
+    return record
+}
+
+private func scriptWindowRecord(_ window: SpaceAPIWindow) -> [String: Any] {
+    var record: [String: Any] = [
+        "id": window.id,
+        "pid": window.pid,
+        "ownerName": window.ownerName,
+        "spaceID": window.spaceID,
+        "isMinimized": window.isMinimized,
+        "isHidden": window.isHidden
+    ]
+    if let appPath = window.appPath {
+        record["appPath"] = appPath
+    }
+    if let title = window.title {
+        record["title"] = title
+    }
+    return record
+}
+
+private func scriptSnapshotRecord(_ snapshot: SpaceAPISnapshot) -> [String: Any] {
+    [
+        "apiVersion": snapshot.apiVersion,
+        "revision": snapshot.revision,
+        "timestamp": snapshot.timestamp,
+        "currentSpaceIDs": snapshot.currentSpaceIDs,
+        "currentSpaceName": snapshot.currentSpaceName,
+        "spaces": snapshot.spaces.map(scriptSpaceRecord)
+    ]
+}
+
+private func scriptWindowsSnapshotRecord(_ snapshot: SpaceAPIWindowsSnapshot) -> [String: Any] {
+    [
+        "apiVersion": snapshot.apiVersion,
+        "revision": snapshot.revision,
+        "timestamp": snapshot.timestamp,
+        "spaces": snapshot.spaces.map(scriptSpaceRecord),
+        "windows": snapshot.windows.map(scriptWindowRecord)
+    ]
+}
+
+class GetAPIInformationCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetAPIInformationCommand")
+        guard isAPIEnabled() else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            scriptErrorNumber = -3
+            scriptErrorString = "DesktopRenamer is not ready."
+            return nil
+        }
+        return runOnMain {
+            let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
+            return scriptAPIInfoRecord(api.makeAPIInfo())
+        }
+    }
+}
+
+class GetStructuredSpacesCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredSpacesCommand")
+        guard isAPIEnabled() else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            scriptErrorNumber = -3
+            scriptErrorString = "DesktopRenamer is not ready."
+            return nil
+        }
+        return runOnMain {
+            let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
+            return api.makeSpaceSnapshotPayload(manager, revision: 0).spaces.map(scriptSpaceRecord)
+        }
+    }
+}
+
+class GetStructuredSnapshotCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredSnapshotCommand")
+        guard isAPIEnabled() else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            scriptErrorNumber = -3
+            scriptErrorString = "DesktopRenamer is not ready."
+            return nil
+        }
+        return runOnMain {
+            let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
+            return scriptSnapshotRecord(api.makeSpaceSnapshotPayload(manager, revision: 0))
+        }
+    }
+}
+
+class GetStructuredWindowsCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredWindowsCommand")
+        guard isAPIEnabled() else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            scriptErrorNumber = -3
+            scriptErrorString = "DesktopRenamer is not ready."
+            return nil
+        }
+        return runOnMain {
+            let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
+            return scriptWindowsSnapshotRecord(api.makeWindowsSnapshotPayload(manager, revision: 0))
+        }
+    }
+}
+
+private func scriptAPIInfoRecord(_ info: SpaceAPIInfo) -> [String: Any] {
+    [
+        "contractVersion": info.contractVersion,
+        "jsonRPCVersion": info.jsonRPCVersion,
+        "supportedMethods": info.supportedMethods,
+        "legacyNotifications": info.legacyNotifications,
+        "eventNotifications": info.eventNotifications,
+        "maxPayloadBytes": info.maxPayloadBytes
+    ]
+}

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -131,7 +131,9 @@ private func scriptAPIInfoRecord(_ info: SpaceAPIInfo) -> [String: Any] {
         "jsonRPCVersion": info.jsonRPCVersion,
         "supportedMethods": info.supportedMethods,
         "legacyNotifications": info.legacyNotifications,
+        "legacyCompatibility": info.legacyCompatibility,
         "eventNotifications": info.eventNotifications,
+        "eventCapabilities": info.eventCapabilities,
         "maxPayloadBytes": info.maxPayloadBytes
     ]
 }

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -104,7 +104,7 @@ class GetStructuredSnapshotCommand: NSScriptCommand {
         }
         return runOnMain {
             let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
-            return scriptSnapshotRecord(api.makeSpaceSnapshotPayload(manager, revision: 0))
+            return scriptSnapshotRecord(api.makeSpaceSnapshotPayload(manager, revision: api.currentSnapshotRevision))
         }
     }
 }
@@ -120,16 +120,16 @@ class GetStructuredWindowsCommand: NSScriptCommand {
         }
         let context = runOnMain {
             let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
-            return (manager.spaceNameDict, api.makeSpaceRecords(manager))
+            return (manager.spaceNameDict, api.makeSpaceRecords(manager), api.currentSnapshotRevision)
         }
-        let (spaces, spaceRecords) = context
+        let (spaces, spaceRecords, revision) = context
 
         // Window enumeration uses CoreGraphics and Accessibility APIs. Keep it
         // outside the main-actor capture so a structured AppleScript read does
         // not hold up the app while it walks other applications' windows.
         let snapshot = SpaceAPIWindowsSnapshot(
             apiVersion: DesktopRenamerAPIVersion.current,
-            revision: 0,
+            revision: revision,
             timestamp: ISO8601DateFormatter().string(from: Date()),
             spaces: spaceRecords,
             windows: SpaceHelper.getWindowRecordsForAllSpaces(spaces: spaces)

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -66,8 +66,7 @@ class GetAPIInformationCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetAPIInformationCommand")
         guard isAPIEnabled() else { return nil }
         guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
-            scriptErrorNumber = -3
-            scriptErrorString = "DesktopRenamer is not ready."
+            _ = failAppUnavailable()
             return nil
         }
         return runOnMain {
@@ -82,8 +81,7 @@ class GetStructuredSpacesCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredSpacesCommand")
         guard isAPIEnabled() else { return nil }
         guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
-            scriptErrorNumber = -3
-            scriptErrorString = "DesktopRenamer is not ready."
+            _ = failAppUnavailable()
             return nil
         }
         return runOnMain {
@@ -98,8 +96,7 @@ class GetStructuredSnapshotCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredSnapshotCommand")
         guard isAPIEnabled() else { return nil }
         guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
-            scriptErrorNumber = -3
-            scriptErrorString = "DesktopRenamer is not ready."
+            _ = failAppUnavailable()
             return nil
         }
         return runOnMain {
@@ -114,8 +111,7 @@ class GetStructuredWindowsCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: GetStructuredWindowsCommand")
         guard isAPIEnabled() else { return nil }
         guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
-            scriptErrorNumber = -3
-            scriptErrorString = "DesktopRenamer is not ready."
+            _ = failAppUnavailable()
             return nil
         }
         let context = runOnMain {

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -88,7 +88,7 @@ class GetStructuredSpacesCommand: NSScriptCommand {
         }
         return runOnMain {
             let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
-            return api.makeSpaceSnapshotPayload(manager, revision: 0).spaces.map(scriptSpaceRecord)
+            return api.makeSpaceRecords(manager).map(scriptSpaceRecord)
         }
     }
 }

--- a/DesktopRenamer/Services/API/StructuredScriptCommands.swift
+++ b/DesktopRenamer/Services/API/StructuredScriptCommands.swift
@@ -118,10 +118,23 @@ class GetStructuredWindowsCommand: NSScriptCommand {
             scriptErrorString = "DesktopRenamer is not ready."
             return nil
         }
-        return runOnMain {
+        let context = runOnMain {
             let api = manager.spaceAPI ?? SpaceAPI(spaceManager: manager)
-            return scriptWindowsSnapshotRecord(api.makeWindowsSnapshotPayload(manager, revision: 0))
+            return (manager.spaceNameDict, api.makeSpaceRecords(manager))
         }
+        let (spaces, spaceRecords) = context
+
+        // Window enumeration uses CoreGraphics and Accessibility APIs. Keep it
+        // outside the main-actor capture so a structured AppleScript read does
+        // not hold up the app while it walks other applications' windows.
+        let snapshot = SpaceAPIWindowsSnapshot(
+            apiVersion: DesktopRenamerAPIVersion.current,
+            revision: 0,
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            spaces: spaceRecords,
+            windows: SpaceHelper.getWindowRecordsForAllSpaces(spaces: spaces)
+        )
+        return scriptWindowsSnapshotRecord(snapshot)
     }
 }
 

--- a/DesktopRenamer/Services/API/WindowScriptCommands.swift
+++ b/DesktopRenamer/Services/API/WindowScriptCommands.swift
@@ -72,7 +72,10 @@ class GetWindowsCommand: NSScriptCommand {
             return (spaces, names)
         }
         
-        guard let (spaces, names) = data else { return "" }
+        guard let (spaces, names) = data else {
+            _ = failAppUnavailable()
+            return nil
+        }
         
         // Perform heavy window enumeration on the background thread (NSScriptCommand defaults to background).
         return SpaceHelper.getWindowsForAllSpaces(spaces: spaces, spaceNames: names)
@@ -151,6 +154,11 @@ class ExecuteWindowActionCommand: NSScriptCommand {
               let pid = Int32(pidStr),
               let actionName = requiredArgumentString("actionName")
         else { return nil }
+        let supportedActions = ["close", "minimize", "hide", "enterFullScreen", "exitFullScreen", "quit", "restore"]
+        guard supportedActions.contains(actionName) else {
+            _ = failInvalidArgument("Unsupported window action: \(actionName)")
+            return nil
+        }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: ExecuteWindowActionCommand (windowID: \(windowIDStr), pid: \(pidStr), actionName: \(actionName))")
         
         // Fire-and-forget: the command returns nil, so there is no need to block

--- a/DesktopRenamer/Services/API/WindowScriptCommands.swift
+++ b/DesktopRenamer/Services/API/WindowScriptCommands.swift
@@ -61,11 +61,12 @@ class ReloadSpaceLabelsCommand: NSScriptCommand {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: ReloadSpaceLabelsCommand")
         guard isAPIEnabled() else { return false }
         return runOnMain {
-            if let manager = AppDelegate.shared.statusBarController?.labelManager {
-                manager.reloadAllWindows()
-                return true
+            guard let manager = AppDelegate.shared.statusBarController?.labelManager else {
+                _ = failAppUnavailable()
+                return nil
             }
-            return false
+            manager.reloadAllWindows()
+            return true
         }
     }
 }
@@ -99,7 +100,7 @@ class GetWindowsCommand: NSScriptCommand {
 class FocusWindowCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
+        guard let windowIDStr = requiredPositiveIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
               let pidStr = requiredProcessIDString(evaluatedArguments?["ownerPID"], parameter: "owner PID"),
               let pid = Int32(pidStr)
@@ -116,7 +117,7 @@ class FocusWindowCommand: NSScriptCommand {
 class MoveSpecificWindowToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
+        guard let windowIDStr = requiredPositiveIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
               let fromSpaceStr = requiredArgumentString("fromSpace"),
               let targetSpaceStr = requiredArgumentString("targetSpace")
@@ -162,14 +163,13 @@ class GetCurrentSpaceIDCommand: NSScriptCommand {
 class ExecuteWindowActionCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
+        guard let windowIDStr = requiredPositiveIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
               let pidStr = requiredProcessIDString(evaluatedArguments?["ownerPID"], parameter: "owner PID"),
               let pid = Int32(pidStr),
               let actionName = requiredArgumentString("actionName")
         else { return nil }
-        let supportedActions = ["close", "minimize", "hide", "enterFullScreen", "exitFullScreen", "quit", "restore"]
-        guard supportedActions.contains(actionName) else {
+        guard DesktopRenamerAPIContract.windowActionNames.contains(actionName) else {
             _ = failInvalidArgument("Unsupported window action: \(actionName)")
             return nil
         }

--- a/DesktopRenamer/Services/API/WindowScriptCommands.swift
+++ b/DesktopRenamer/Services/API/WindowScriptCommands.swift
@@ -30,7 +30,7 @@ class MoveWindowPreviousCommand: NSScriptCommand {
 class MoveWindowToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let spaceID = self.directParameter as? String else { return nil }
+        guard let spaceID = requiredDirectString(parameter: "space ID") else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: MoveWindowToSpaceCommand (spaceID: \(spaceID))")
         
         DispatchQueue.main.async {
@@ -82,10 +82,9 @@ class GetWindowsCommand: NSScriptCommand {
 class FocusWindowCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = self.directParameter as? String,
+        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
-              let arguments = self.evaluatedArguments,
-              let pidStr = arguments["ownerPID"] as? String,
+              let pidStr = requiredProcessIDString(evaluatedArguments?["ownerPID"], parameter: "owner PID"),
               let pid = Int32(pidStr)
         else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: FocusWindowCommand (windowID: \(windowIDStr), pid: \(pidStr))")
@@ -100,16 +99,17 @@ class FocusWindowCommand: NSScriptCommand {
 class MoveSpecificWindowToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = self.directParameter as? String,
+        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
-              let arguments = self.evaluatedArguments,
-              let fromSpaceStr = arguments["fromSpace"] as? String,
-              let targetSpaceStr = arguments["targetSpace"] as? String
+              let fromSpaceStr = requiredArgumentString("fromSpace"),
+              let targetSpaceStr = requiredArgumentString("targetSpace")
         else { return nil }
+        let arguments = evaluatedArguments ?? [:]
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: MoveSpecificWindowToSpaceCommand (windowID: \(windowIDStr), fromSpace: \(fromSpaceStr), targetSpace: \(targetSpaceStr))")
 
-        if let pidStr = arguments["ownerPID"] as? String,
-           let pid = Int32(pidStr) {
+        if let pidValue = arguments["ownerPID"] {
+            guard let pidStr = requiredProcessIDString(pidValue, parameter: "owner PID"),
+                  let pid = Int32(pidStr) else { return nil }
             Task { @MainActor in
                 await WindowActionCoordinator.moveWindow(
                     windowID: windowID,
@@ -123,6 +123,9 @@ class MoveSpecificWindowToSpaceCommand: NSScriptCommand {
             DispatchQueue.main.async {
                 SpaceHelper.moveWindowToSpace(windowID: windowID, fromSpaceID: fromSpaceID, targetSpaceID: targetSpaceID)
             }
+        } else {
+            failInvalidArgument("Space IDs must be integer values when owner PID is omitted.")
+            return nil
         }
         return nil
     }
@@ -142,12 +145,11 @@ class GetCurrentSpaceIDCommand: NSScriptCommand {
 class ExecuteWindowActionCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
-        guard let windowIDStr = self.directParameter as? String,
+        guard let windowIDStr = requiredIntegerString(directParameter, parameter: "window ID"),
               let windowID = Int(windowIDStr),
-              let arguments = self.evaluatedArguments,
-              let pidStr = arguments["ownerPID"] as? String,
+              let pidStr = requiredProcessIDString(evaluatedArguments?["ownerPID"], parameter: "owner PID"),
               let pid = Int32(pidStr),
-              let actionName = arguments["actionName"] as? String
+              let actionName = requiredArgumentString("actionName")
         else { return nil }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: ExecuteWindowActionCommand (windowID: \(windowIDStr), pid: \(pidStr), actionName: \(actionName))")
         

--- a/DesktopRenamer/Services/API/WindowScriptCommands.swift
+++ b/DesktopRenamer/Services/API/WindowScriptCommands.swift
@@ -5,6 +5,10 @@ class MoveWindowNextCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: MoveWindowNextCommand")
         guard isAPIEnabled() else { return nil }
+        guard runOnMain({ AppDelegate.shared.spaceManager != nil }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
         DispatchQueue.main.async {
             if let manager = AppDelegate.shared.spaceManager {
                 manager.moveActiveWindowToNextSpace()
@@ -18,6 +22,10 @@ class MoveWindowPreviousCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: MoveWindowPreviousCommand")
         guard isAPIEnabled() else { return nil }
+        guard runOnMain({ AppDelegate.shared.spaceManager != nil }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
         DispatchQueue.main.async {
             if let manager = AppDelegate.shared.spaceManager {
                 manager.moveActiveWindowToPreviousSpace()
@@ -31,12 +39,18 @@ class MoveWindowToSpaceCommand: NSScriptCommand {
     override func performDefaultImplementation() -> Any? {
         guard isAPIEnabled() else { return nil }
         guard let spaceID = requiredDirectString(parameter: "space ID") else { return nil }
+        guard let manager = runOnMain({ AppDelegate.shared.spaceManager }) else {
+            _ = failAppUnavailable()
+            return nil
+        }
+        guard runOnMain({ manager.spaceNameDict.contains(where: { $0.id == spaceID }) }) else {
+            _ = failInvalidArgument("Invalid space ID.")
+            return nil
+        }
         DiagnosticEventLog.shared.record(subsystem: "AppleScript", level: "info", "Command performed: MoveWindowToSpaceCommand (spaceID: \(spaceID))")
         
         DispatchQueue.main.async {
-            if let manager = AppDelegate.shared.spaceManager {
-                manager.moveActiveWindowToSpace(id: spaceID)
-            }
+            manager.moveActiveWindowToSpace(id: spaceID)
         }
         return nil
     }

--- a/DesktopRenamer/Services/Space/SpaceHelper.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper.swift
@@ -49,10 +49,11 @@ class SpaceHelper {
     static var lastProgrammaticSwitchTime: TimeInterval = 0
     static var lastProgrammaticTargetSpaceID: String? = nil
     static var lastProgrammaticSwitchUsedSLS = false
-    // A WindowServer space read can reach SpaceManager before macOS delivers
-    // the active-space notification. Keep the programmatic transition open
-    // until both signals have arrived, so label restoration cannot use the
-    // first destination snapshot as proof that the animation has finished.
+    // WindowServer state is the authoritative completion signal. The
+    // active-space notification is useful corroboration, but it is delivered
+    // through a lossy XPC path and can be absent even after the destination is
+    // current. The generation-scoped settle verification below prevents one
+    // early snapshot from completing the transition by itself.
     static var programmaticSwitchDestinationObserved = false
     static var programmaticSwitchNotificationObserved = false
     static var programmaticSwitchCompletionWorkItem: DispatchWorkItem?

--- a/DesktopRenamer/Services/Space/SpaceHelper.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper.swift
@@ -36,6 +36,13 @@ class SpaceHelper {
     // change. Dock activation and mouse events can otherwise queue several
     // reads whose callbacks arrive after a newer transition has started.
     static var spaceDetectionGeneration = 0
+    // The raw WindowServer scan is relatively expensive because it also walks
+    // the on-screen window list. Keep only the newest scheduled scan so a
+    // burst of activation or mouse events cannot occupy the main queue after
+    // a gesture has already begun.
+    static let rawSpaceUUIDStateLock = NSLock()
+    static var rawSpaceUUIDWorkItem: DispatchWorkItem?
+    static var rawSpaceUUIDGeneration = 0
 
     // Tracks switching state to prevent recursion during transitions.
     static var isSwitching = false
@@ -69,6 +76,14 @@ class SpaceHelper {
     static var pendingProgrammaticSwitchTargetSpaceID: String? {
         switchTransactionCoordinator.pending?.spaceID
             ?? programmaticSwitchPromotionRequest?.spaceID
+    }
+
+    // `isSwitching` becomes false for the short settle interval before a
+    // coalesced request is promoted. Gesture requests must not run in that
+    // gap or they can race the promotion and discard the latest destination.
+    static var isProgrammaticSwitchPromotionPending: Bool {
+        programmaticSwitchPromotionRequest != nil
+            || programmaticSwitchPromotionWorkItem != nil
     }
 
     /// Current transaction state for diagnostic reports. The generation makes

--- a/DesktopRenamer/Services/Space/SpaceHelper.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper.swift
@@ -56,6 +56,8 @@ class SpaceHelper {
     // early snapshot from completing the transition by itself.
     static var programmaticSwitchDestinationObserved = false
     static var programmaticSwitchNotificationObserved = false
+    static var programmaticSwitchUsesExtendedSettle = false
+    static var programmaticSwitchFastFollowUpRequested = false
     static var programmaticSwitchCompletionWorkItem: DispatchWorkItem?
     static var programmaticSwitchTimeoutWorkItem: DispatchWorkItem?
     static var fullscreenGestureRetryWorkItem: DispatchWorkItem?

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -33,6 +33,7 @@ extension SpaceHelper {
 
     static func stopMonitoring() {
         spaceDetectionGeneration += 1
+        cancelPendingRawSpaceUUIDScan()
         programmaticSwitchCompletionWorkItem?.cancel()
         programmaticSwitchCompletionWorkItem = nil
         programmaticSwitchTimeoutWorkItem?.cancel()
@@ -69,84 +70,246 @@ extension SpaceHelper {
         onSpaceChange = nil
     }
 
-    private static func getActiveDisplay() -> NSScreen? {
-        if let frontApp = NSWorkspace.shared.frontmostApplication,
-            frontApp.bundleIdentifier != "com.apple.finder"
-        {
-            let options = CGWindowListOption(
-                arrayLiteral: .optionOnScreenOnly, .excludeDesktopElements)
-            let windowList =
-                CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
+    private struct RawSpaceScreen {
+        let screenID: CGDirectDisplayID
+        let frame: CGRect
+        let localizedName: String
+    }
 
+    private struct RawSpaceScanContext {
+        let screens: [RawSpaceScreen]
+        let primaryScreenMaxY: CGFloat
+        let frontmostProcessID: Int32?
+        let mouseLocation: CGPoint
+    }
+
+    private struct RawSpaceScanResult {
+        let uuid: String
+        let hasFinderDesktop: Bool
+        let notificationCount: Int
+        let displayIdentifier: String
+    }
+
+    private static func makeRawSpaceScanContext() -> RawSpaceScanContext? {
+        let screens = NSScreen.screens.compactMap { screen -> RawSpaceScreen? in
+            guard let screenID = screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber")
+            ] as? CGDirectDisplayID else {
+                return nil
+            }
+            return RawSpaceScreen(
+                screenID: screenID,
+                frame: screen.frame,
+                localizedName: screen.localizedName
+            )
+        }
+        guard !screens.isEmpty else { return nil }
+
+        let primaryScreenMaxY = NSScreen.screens.first(where: {
+            $0.frame.origin.x == 0 && $0.frame.origin.y == 0
+        })?.frame.maxY ?? screens[0].frame.maxY
+
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        let frontmostProcessID: Int32?
+        if frontmostApplication?.bundleIdentifier == "com.apple.finder" {
+            frontmostProcessID = nil
+        } else {
+            frontmostProcessID = frontmostApplication?.processIdentifier
+        }
+
+        return RawSpaceScanContext(
+            screens: screens,
+            primaryScreenMaxY: primaryScreenMaxY,
+            frontmostProcessID: frontmostProcessID,
+            mouseLocation: NSEvent.mouseLocation
+        )
+    }
+
+    private static func isPoint(
+        _ point: CGPoint,
+        inside screenFrame: CGRect,
+        primaryScreenMaxY: CGFloat
+    ) -> Bool {
+        let flippedY = primaryScreenMaxY - point.y
+        return screenFrame.contains(CGPoint(x: point.x, y: flippedY))
+    }
+
+    private static func scanRawSpace(_ context: RawSpaceScanContext) -> RawSpaceScanResult? {
+        let options = CGWindowListOption(arrayLiteral: .optionOnScreenOnly)
+        let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
+            as? [[String: Any]] ?? []
+
+        var activeScreen: RawSpaceScreen?
+        if let frontmostProcessID = context.frontmostProcessID {
             for window in windowList {
-                if let pid = window[kCGWindowOwnerPID as String] as? Int,
-                    pid == frontApp.processIdentifier,
-                    let layer = window[kCGWindowLayer as String] as? Int, layer == 0,
-                    let bounds = window[kCGWindowBounds as String] as? [String: Any],
-                    let x = bounds["X"] as? CGFloat, let y = bounds["Y"] as? CGFloat,
-                    let w = bounds["Width"] as? CGFloat, let h = bounds["Height"] as? CGFloat
-                {
-                    let center = CGPoint(x: x + w / 2, y: y + h / 2)
-                    for screen in NSScreen.screens {
-                        if isPoint(center, inside: screen.frame) { return screen }
-                    }
+                guard let pid = window[kCGWindowOwnerPID as String] as? Int,
+                      pid == Int(frontmostProcessID),
+                      let layer = window[kCGWindowLayer as String] as? Int,
+                      layer == 0,
+                      let bounds = window[kCGWindowBounds as String] as? [String: Any],
+                      let x = bounds["X"] as? CGFloat,
+                      let y = bounds["Y"] as? CGFloat,
+                      let width = bounds["Width"] as? CGFloat,
+                      let height = bounds["Height"] as? CGFloat else {
+                    continue
                 }
+
+                let center = CGPoint(x: x + width / 2, y: y + height / 2)
+                activeScreen = context.screens.first(where: {
+                    isPoint(
+                        center,
+                        inside: $0.frame,
+                        primaryScreenMaxY: context.primaryScreenMaxY
+                    )
+                })
+                if activeScreen != nil { break }
             }
         }
-        let mouseLocation = NSEvent.mouseLocation
-        return NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+
+        if activeScreen == nil {
+            activeScreen = context.screens.first(where: {
+                isPoint(
+                    context.mouseLocation,
+                    inside: $0.frame,
+                    primaryScreenMaxY: context.primaryScreenMaxY
+                )
+            })
+        }
+
+        guard let activeScreen else {
+            return RawSpaceScanResult(
+                uuid: "",
+                hasFinderDesktop: false,
+                notificationCount: 0,
+                displayIdentifier: "Unknown"
+            )
+        }
+
+        let displayIdentifier = activeScreen.localizedName
+            + " ("
+            + String(activeScreen.screenID)
+            + ")"
+        var resolvedDisplayIdentifier = displayIdentifier
+        if let uuidRef = CGDisplayCreateUUIDFromDisplayID(activeScreen.screenID) {
+            let uuid = uuidRef.takeRetainedValue()
+            if let uuidString = CFUUIDCreateString(nil, uuid) as String? {
+                resolvedDisplayIdentifier = uuidString.uppercased()
+            }
+        }
+
+        var uuid = ""
+        var notificationCount = 0
+        var hasFinderDesktop = false
+        for window in windowList {
+            guard let bounds = window[kCGWindowBounds as String] as? [String: Any],
+                  let x = bounds["X"] as? CGFloat,
+                  let y = bounds["Y"] as? CGFloat,
+                  let width = bounds["Width"] as? CGFloat,
+                  let height = bounds["Height"] as? CGFloat,
+                  isPoint(
+                      CGPoint(x: x + width / 2, y: y + height / 2),
+                      inside: activeScreen.frame,
+                      primaryScreenMaxY: context.primaryScreenMaxY
+                  ),
+                  let owner = window[kCGWindowOwnerName as String] as? String else {
+                continue
+            }
+
+            if owner == "Dock",
+               let name = window[kCGWindowName as String] as? String,
+               name.starts(with: "Wallpaper-") {
+                uuid = String(name.dropFirst("Wallpaper-".count))
+                if uuid.isEmpty { uuid = "MAIN" }
+            }
+            if owner == "Notification Center" {
+                notificationCount += 1
+            }
+            if owner == "Finder",
+               let layer = window[kCGWindowLayer as String] as? Int,
+               layer < 0 {
+                hasFinderDesktop = true
+            }
+        }
+
+        return RawSpaceScanResult(
+            uuid: uuid,
+            hasFinderDesktop: hasFinderDesktop,
+            notificationCount: notificationCount,
+            displayIdentifier: resolvedDisplayIdentifier
+        )
     }
 
     static func getRawSpaceUUID(completion: @escaping (String, Bool, Int, String) -> Void) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            guard let activeScreen = getActiveDisplay() else {
+        // Snapshot AppKit state and schedule the scan from the main queue.
+        // Callers are normally already on main, but this also prevents a
+        // background caller from racing the monitor lifecycle state.
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async {
+                getRawSpaceUUID(completion: completion)
+            }
+            return
+        }
+
+        rawSpaceUUIDStateLock.lock()
+        rawSpaceUUIDWorkItem?.cancel()
+        rawSpaceUUIDGeneration += 1
+        let generation = rawSpaceUUIDGeneration
+
+        let workItem = DispatchWorkItem {
+            rawSpaceUUIDStateLock.lock()
+            guard generation == rawSpaceUUIDGeneration else {
+                rawSpaceUUIDStateLock.unlock()
+                return
+            }
+            // Clear this before invoking the callback. The callback may
+            // immediately request another scan, which must remain registered.
+            rawSpaceUUIDWorkItem = nil
+            rawSpaceUUIDStateLock.unlock()
+
+            guard let context = makeRawSpaceScanContext() else {
+                guard isCurrentRawSpaceUUIDGeneration(generation) else { return }
                 completion("", false, 0, "Unknown")
                 return
             }
-            let screenID =
-                activeScreen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
-                as? NSNumber ?? 0
-            
-            var displayIdentifier = "\(activeScreen.localizedName) (\(screenID))"
-            if let uuidRef = CGDisplayCreateUUIDFromDisplayID(screenID.uint32Value) {
-                let uuid = uuidRef.takeRetainedValue()
-                if let uuidStr = CFUUIDCreateString(nil, uuid) as String? {
-                    displayIdentifier = uuidStr.uppercased()
+
+            // CGWindowListCopyWindowInfo is independent of AppKit state. Run
+            // the potentially expensive enumeration away from the main queue,
+            // then deliver the existing callback contract back on main.
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let result = scanRawSpace(context) else { return }
+                DispatchQueue.main.async {
+                    guard isCurrentRawSpaceUUIDGeneration(generation) else { return }
+                    completion(
+                        result.uuid,
+                        result.hasFinderDesktop,
+                        result.notificationCount,
+                        result.displayIdentifier
+                    )
                 }
             }
-
-            let options = CGWindowListOption(arrayLiteral: .optionOnScreenOnly)
-            let windowList =
-                CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] ?? []
-
-            var uuid = ""
-            var ncCnt = 0
-            var hasFinderDesktop = false
-            for window in windowList {
-                guard let bounds = window[kCGWindowBounds as String] as? [String: Any],
-                    let x = bounds["X"] as? CGFloat, let y = bounds["Y"] as? CGFloat,
-                    let w = bounds["Width"] as? CGFloat, let h = bounds["Height"] as? CGFloat
-                else { continue }
-
-                if isPoint(CGPoint(x: x + w / 2, y: y + h / 2), inside: activeScreen.frame),
-                    let owner = window[kCGWindowOwnerName as String] as? String
-                {
-                    if owner == "Dock", let name = window[kCGWindowName as String] as? String,
-                        name.starts(with: "Wallpaper-")
-                    {
-                        uuid = String(name.dropFirst("Wallpaper-".count))
-                        if uuid == "" { uuid = "MAIN" }
-                    }
-                    if owner == "Notification Center" { ncCnt += 1 }
-                    if owner == "Finder", let layer = window[kCGWindowLayer as String] as? Int,
-                        layer < 0
-                    {
-                        hasFinderDesktop = true
-                    }
-                }
-            }
-            completion(uuid, hasFinderDesktop, ncCnt, displayIdentifier)
         }
+
+        rawSpaceUUIDWorkItem = workItem
+        rawSpaceUUIDStateLock.unlock()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+    }
+
+    /// Cancels a pending raw space scan without blocking the multitouch
+    /// callback. The generation check also discards a scan that has already
+    /// started but has not reached its completion callback.
+    static func cancelPendingRawSpaceUUIDScan() {
+        rawSpaceUUIDStateLock.lock()
+        rawSpaceUUIDGeneration += 1
+        let workItem = rawSpaceUUIDWorkItem
+        rawSpaceUUIDWorkItem = nil
+        rawSpaceUUIDStateLock.unlock()
+        workItem?.cancel()
+    }
+
+    private static func isCurrentRawSpaceUUIDGeneration(_ generation: Int) -> Bool {
+        rawSpaceUUIDStateLock.lock()
+        defer { rawSpaceUUIDStateLock.unlock() }
+        return generation == rawSpaceUUIDGeneration
     }
 
     static func getAllDisplayUUIDs() -> [String] {
@@ -177,7 +340,10 @@ extension SpaceHelper {
         return cleanId.uppercased()
     }
 
-    static func getSystemState(onDisplayID specificDisplayID: String? = nil) -> (
+    static func getSystemState(
+        onDisplayID specificDisplayID: String? = nil,
+        includeFullscreenAppMetadata: Bool = true
+    ) -> (
         spaces: [DesktopSpace], currentUUID: String, displayID: String
     )? {
         let conn = _CGSDefaultConnection()
@@ -239,7 +405,7 @@ extension SpaceHelper {
                 var appPath: String? = nil
                 var globalShortcutNum: Int? = nil
 
-                if isFullscreen {
+                if isFullscreen, includeFullscreenAppMetadata {
                     if let p = space["pid"] as? Int32 ?? space["owner pid"] as? Int32 {
                         if let runningApp = NSRunningApplication(processIdentifier: p) {
                             appName = runningApp.localizedName

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -526,9 +526,24 @@ extension SpaceHelper {
 
         var output = ""
         for space in sortedSpaces {
-            output += ">\(space.id)~\(spaceNames[space.id] ?? "")~\(getDisplayName(for: space.displayID, screenMap: screenMap))~\(space.num)~\(space.isFullscreen ? "1" : "0")~\(space.appPath ?? "")\n"
+            output += SpaceAPILegacyFormatter.spaceLine(
+                id: space.id,
+                name: spaceNames[space.id] ?? "",
+                displayName: getDisplayName(for: space.displayID, screenMap: screenMap),
+                number: space.num,
+                isFullscreen: space.isFullscreen,
+                appPath: space.appPath
+            )
             for window in records where window.spaceID == space.id {
-                output += "  \(window.id)|\(window.pid)|\(window.ownerName)|\(window.appPath ?? "")|\(window.title ?? "")|\(window.isMinimized ? "1" : "0")|\(window.isHidden ? "1" : "0")\n"
+                output += SpaceAPILegacyFormatter.windowLine(
+                    id: window.id,
+                    pid: window.pid,
+                    ownerName: window.ownerName,
+                    appPath: window.appPath,
+                    title: window.title,
+                    isMinimized: window.isMinimized,
+                    isHidden: window.isHidden
+                )
             }
         }
         return output

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -527,6 +527,7 @@ extension SpaceHelper {
             if $0.displayID != $1.displayID { return $0.displayID < $1.displayID }
             return $0.num < $1.num
         }
+        let windowsBySpaceID = Dictionary(grouping: records, by: \.spaceID)
 
         var output = ""
         for space in sortedSpaces {
@@ -538,7 +539,7 @@ extension SpaceHelper {
                 isFullscreen: space.isFullscreen,
                 appPath: space.appPath
             )
-            for window in records where window.spaceID == space.id {
+            for window in windowsBySpaceID[space.id] ?? [] {
                 output += SpaceAPILegacyFormatter.windowLine(
                     id: window.id,
                     pid: window.pid,

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -400,6 +400,12 @@ extension SpaceHelper {
                 guard let managedID = space["ManagedSpaceID"] as? Int else { continue }
                 let idString = String(managedID)
                 let isFullscreen = space["TileLayoutManager"] != nil
+                let rawPersistentID = space["uuid"] as? String
+                let persistentID = rawPersistentID.flatMap {
+                    let normalized = $0.trimmingCharacters(in: .whitespacesAndNewlines)
+                        .uppercased()
+                    return normalized.isEmpty ? nil : normalized
+                }
 
                 var appName: String? = nil
                 var appPath: String? = nil
@@ -427,7 +433,8 @@ extension SpaceHelper {
                         isFullscreen: isFullscreen,
                         appName: appName,
                         appPath: appPath,
-                        globalShortcutNum: globalShortcutNum
+                        globalShortcutNum: globalShortcutNum,
+                        persistentID: persistentID
                     ))
 
                 if let currentDict = display["Current Space"] as? [String: Any],

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -315,6 +315,10 @@ extension SpaceHelper {
     }
 
     static func getWindowRecordsForAllSpaces(spaces: [DesktopSpace]) -> [SpaceAPIWindow] {
+        getWindowRecordsForAllSpacesIfAvailable(spaces: spaces) ?? []
+    }
+
+    private static func getWindowRecordsForAllSpacesIfAvailable(spaces: [DesktopSpace]) -> [SpaceAPIWindow]? {
         let conn = _CGSDefaultConnection()
         let ourPID = ProcessInfo.processInfo.processIdentifier
 
@@ -368,7 +372,7 @@ extension SpaceHelper {
         let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements)
         guard let allWindows = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
                 as? [[String: Any]]
-        else { return [] }
+        else { return nil }
 
         // Collect valid windows with their IDs.
         var validWindows: [(wid: Int, dict: [String: Any])] = []
@@ -420,7 +424,7 @@ extension SpaceHelper {
         // Fallback: assign windows to current space per display if CGS API unavailable or empty.
         if windowsBySpaceID.isEmpty {
             // Build current-space-per-display map and fullscreen PID→space map.
-            guard let displays = CGSCopyManagedDisplaySpaces(conn) as? [NSDictionary] else { return [] }
+            guard let displays = CGSCopyManagedDisplaySpaces(conn) as? [NSDictionary] else { return nil }
             let screenUUIDs = getAllDisplayUUIDs()
             let mainUUID = screenUUIDs.first
             var currentSpaceForDisplay: [String: String] = [:]
@@ -509,7 +513,7 @@ extension SpaceHelper {
     /// Returns the historical delimiter-based representation for existing clients.
     /// New integrations should use getWindowRecordsForAllSpaces instead.
     static func getWindowsForAllSpaces(spaces: [DesktopSpace], spaceNames: [String: String]) -> String {
-        let records = getWindowRecordsForAllSpaces(spaces: spaces)
+        guard let records = getWindowRecordsForAllSpacesIfAvailable(spaces: spaces) else { return "" }
         var screenMap: [String: String] = [:]
         for screen in NSScreen.screens {
             if let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,

--- a/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/MonitoringAndEnumeration.swift
@@ -314,20 +314,9 @@ extension SpaceHelper {
         return true
     }
 
-    static func getWindowsForAllSpaces(spaces: [DesktopSpace], spaceNames: [String: String]) -> String {
+    static func getWindowRecordsForAllSpaces(spaces: [DesktopSpace]) -> [SpaceAPIWindow] {
         let conn = _CGSDefaultConnection()
         let ourPID = ProcessInfo.processInfo.processIdentifier
-
-        // Pre-calculate screen mapping for efficiency as recommended by reviewer.
-        var screenMap: [String: String] = [:]
-        for screen in NSScreen.screens {
-            if let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
-               let uuidRef = CGDisplayCreateUUIDFromDisplayID(id) {
-                let uuid = uuidRef.takeRetainedValue()
-                let uuidStr = (CFUUIDCreateString(nil, uuid) as String).uppercased()
-                screenMap[uuidStr] = screen.localizedName
-            }
-        }
 
         // Build PID → app bundle path cache from running applications.
         // Only include apps with .regular activation policy (shown in Dock).
@@ -379,7 +368,7 @@ extension SpaceHelper {
         let options = CGWindowListOption(arrayLiteral: .excludeDesktopElements)
         guard let allWindows = CGWindowListCopyWindowInfo(options, kCGNullWindowID)
                 as? [[String: Any]]
-        else { return "" }
+        else { return [] }
 
         // Collect valid windows with their IDs.
         var validWindows: [(wid: Int, dict: [String: Any])] = []
@@ -431,7 +420,7 @@ extension SpaceHelper {
         // Fallback: assign windows to current space per display if CGS API unavailable or empty.
         if windowsBySpaceID.isEmpty {
             // Build current-space-per-display map and fullscreen PID→space map.
-            guard let displays = CGSCopyManagedDisplaySpaces(conn) as? [NSDictionary] else { return "" }
+            guard let displays = CGSCopyManagedDisplaySpaces(conn) as? [NSDictionary] else { return [] }
             let screenUUIDs = getAllDisplayUUIDs()
             let mainUUID = screenUUIDs.first
             var currentSpaceForDisplay: [String: String] = [:]
@@ -492,7 +481,44 @@ extension SpaceHelper {
             }
         }
 
-        // Build output sorted by display then number.
+        return spaces
+            .sorted {
+                if $0.displayID != $1.displayID { return $0.displayID < $1.displayID }
+                return $0.num < $1.num
+            }
+            .flatMap { space in
+                (windowsBySpaceID[space.id] ?? []).compactMap { window -> SpaceAPIWindow? in
+                    guard let wid = window[kCGWindowNumber as String] as? Int,
+                          let pid = window[kCGWindowOwnerPID as String] as? Int,
+                          let appPath = pidToAppPath[Int32(pid)] else { return nil }
+
+                    return SpaceAPIWindow(
+                        id: wid,
+                        pid: Int32(pid),
+                        ownerName: window[kCGWindowOwnerName as String] as? String ?? "",
+                        appPath: appPath,
+                        title: window[kCGWindowName as String] as? String,
+                        spaceID: space.id,
+                        isMinimized: minimizedAXWindowIDs.contains(wid),
+                        isHidden: NSRunningApplication(processIdentifier: Int32(pid))?.isHidden ?? false
+                    )
+                }
+            }
+    }
+
+    /// Returns the historical delimiter-based representation for existing clients.
+    /// New integrations should use getWindowRecordsForAllSpaces instead.
+    static func getWindowsForAllSpaces(spaces: [DesktopSpace], spaceNames: [String: String]) -> String {
+        let records = getWindowRecordsForAllSpaces(spaces: spaces)
+        var screenMap: [String: String] = [:]
+        for screen in NSScreen.screens {
+            if let id = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+               let uuidRef = CGDisplayCreateUUIDFromDisplayID(id) {
+                let uuid = uuidRef.takeRetainedValue()
+                let uuidString = (CFUUIDCreateString(nil, uuid) as String).uppercased()
+                screenMap[uuidString] = screen.localizedName
+            }
+        }
         let sortedSpaces = spaces.sorted {
             if $0.displayID != $1.displayID { return $0.displayID < $1.displayID }
             return $0.num < $1.num
@@ -500,22 +526,9 @@ extension SpaceHelper {
 
         var output = ""
         for space in sortedSpaces {
-            let name = spaceNames[space.id] ?? ""
-            let displayName = getDisplayName(for: space.displayID, screenMap: screenMap)
-            output += ">\(space.id)~\(name)~\(displayName)~\(space.num)~\(space.isFullscreen ? "1" : "0")~\(space.appPath ?? "")\n"
-
-            guard let windows = windowsBySpaceID[space.id] else { continue }
-            for window in windows {
-                guard let wid = window[kCGWindowNumber as String] as? Int,
-                      let pid = window[kCGWindowOwnerPID as String] as? Int,
-                      let appPath = pidToAppPath[Int32(pid)]
-                else { continue }
-
-                let ownerName = window[kCGWindowOwnerName as String] as? String ?? ""
-                let title = window[kCGWindowName as String] as? String ?? ""
-                let isMinimized = minimizedAXWindowIDs.contains(wid) ? "1" : "0"
-                let isHidden = (NSRunningApplication(processIdentifier: Int32(pid))?.isHidden ?? false) ? "1" : "0"
-                output += "  \(wid)|\(pid)|\(ownerName)|\(appPath)|\(title)|\(isMinimized)|\(isHidden)\n"
+            output += ">\(space.id)~\(spaceNames[space.id] ?? "")~\(getDisplayName(for: space.displayID, screenMap: screenMap))~\(space.num)~\(space.isFullscreen ? "1" : "0")~\(space.appPath ?? "")\n"
+            for window in records where window.spaceID == space.id {
+                output += "  \(window.id)|\(window.pid)|\(window.ownerName)|\(window.appPath ?? "")|\(window.title ?? "")|\(window.isMinimized ? "1" : "0")|\(window.isHidden ? "1" : "0")\n"
             }
         }
         return output

--- a/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
@@ -559,6 +559,15 @@ extension SpaceHelper {
                 "programmatic switch confirmed: generation=\(generation), target=\(spaceID)"
             )
             NotificationCenter.default.post(
+                name: NSNotification.Name("SpaceProgrammaticSwitchFinished"),
+                object: nil,
+                userInfo: [
+                    "spaceID": spaceID,
+                    "generation": generation,
+                    "confirmed": true
+                ]
+            )
+            NotificationCenter.default.post(
                 name: NSNotification.Name("SpaceProgrammaticSwitchSettled"),
                 object: nil,
                 userInfo: ["spaceID": spaceID, "generation": generation]
@@ -573,6 +582,15 @@ extension SpaceHelper {
                 subsystem: "SpaceHelper",
                 level: "warning",
                 "programmatic switch timed out: generation=\(generation), target=\(spaceID)"
+            )
+            NotificationCenter.default.post(
+                name: NSNotification.Name("SpaceProgrammaticSwitchFinished"),
+                object: nil,
+                userInfo: [
+                    "spaceID": spaceID,
+                    "generation": generation,
+                    "confirmed": false
+                ]
             )
         }
 

--- a/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
@@ -560,8 +560,9 @@ extension SpaceHelper {
     }
 
     /// Records that SpaceManager has read the requested destination from live
-    /// WindowServer state. The active-space notification is also required
-    /// before the transition is considered complete.
+    /// WindowServer state. NSWorkspace's active-space notification can be
+    /// dropped when its XPC session resets, so a stable WindowServer result is
+    /// sufficient after the normal settle verification.
     static func markProgrammaticSwitchComplete(at spaceID: String) {
         guard let active = switchTransactionCoordinator.active,
               isSwitching,
@@ -575,13 +576,12 @@ extension SpaceHelper {
             return
         }
         programmaticSwitchDestinationObserved = true
-        guard programmaticSwitchNotificationObserved else {
+        if !programmaticSwitchNotificationObserved {
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceHelper",
                 level: "info",
-                "programmatic destination observed at space \(spaceID); waiting for active-space notification"
+                "programmatic destination observed at space \(spaceID) without active-space notification; using WindowServer settle verification"
             )
-            return
         }
 
         finishProgrammaticSwitch(at: spaceID, generation: active.generation)
@@ -601,10 +601,10 @@ extension SpaceHelper {
     private static func finishProgrammaticSwitch(at spaceID: String, generation: UInt64) {
         guard programmaticSwitchCompletionWorkItem == nil else { return }
 
-        // The first matching WindowServer read and the active-space
-        // notification can both arrive before the visual swipe has finished.
-        // Keep the transition open for one settling interval, then notify the
-        // label manager so it can perform its own stable-state verification.
+        // The first matching WindowServer read can arrive before the visual
+        // swipe has finished. Keep the transition open for one settling
+        // interval, then verify the authoritative live state again before
+        // releasing queued requests and restoring labels.
         let workItem = DispatchWorkItem {
             guard let active = switchTransactionCoordinator.active,
                   isSwitching,

--- a/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
@@ -108,6 +108,79 @@ extension SpaceHelper {
         return startSpaceSwitch(context, forceInstant: forceInstant, isManual: isManual)
     }
 
+    /// Resolves one adjacent space from a single managed-space snapshot. The
+    /// gesture override uses this path so it does not first ask SpaceManager
+    /// for the current space and then ask WindowServer for the same state again
+    /// before emitting the synthetic gesture.
+    @discardableResult
+    static func switchToAdjacentSpace(
+        direction: Int,
+        onDisplayID requestedDisplayID: String? = nil,
+        forceInstant: Bool = false,
+        isManual: Bool = false
+    ) -> SpaceSwitchRequestDisposition {
+        guard direction != 0,
+              let state = getSystemState(includeFullscreenAppMetadata: false) else {
+            return .unavailable
+        }
+
+        let displayID = requestedDisplayID ?? state.displayID
+        let liveCurrentSpaceID: String?
+        if displayID == state.displayID {
+            liveCurrentSpaceID = state.currentUUID
+        } else {
+            liveCurrentSpaceID = getCurrentSpaceID(for: displayID)
+        }
+
+        let displaySpaces = state.spaces
+            .filter { $0.displayID == displayID }
+            .sorted { $0.num < $1.num }
+
+        guard let liveCurrentSpaceID,
+              let currentIndex = displaySpaces.firstIndex(where: {
+                  $0.id == liveCurrentSpaceID
+              }) else {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceHelper",
+                level: "warning",
+                "adjacent switch unavailable: display="
+                    + displayID
+                    + ", current="
+                    + (liveCurrentSpaceID ?? "nil")
+                    + ", direction="
+                    + String(direction)
+            )
+            return .unavailable
+        }
+
+        let targetIndex = currentIndex + direction
+        guard displaySpaces.indices.contains(targetIndex) else {
+            return .unavailable
+        }
+        let targetSpace = displaySpaces[targetIndex]
+        let context = makeSpaceSwitchContext(
+            state: state,
+            targetSpace: targetSpace,
+            liveCurrentSpaceID: liveCurrentSpaceID
+        )
+
+        // If another request won the race after the snapshot, let the normal
+        // absolute-target path coalesce this request instead of starting a
+        // second primitive.
+        if !forceInstant, switchTransactionCoordinator.active != nil {
+            return switchToSpace(
+                targetSpace.id,
+                forceInstant: false,
+                isManual: isManual
+            )
+        }
+
+        if liveCurrentSpaceID == targetSpace.id {
+            return .alreadyCurrent
+        }
+        return startSpaceSwitch(context, forceInstant: forceInstant, isManual: isManual)
+    }
+
     private static func makeSpaceSwitchContext(for spaceID: String) -> SpaceSwitchContext? {
         guard let state = getSystemState(),
               let targetSpace = state.spaces.first(where: { $0.id == spaceID }) else {
@@ -119,6 +192,19 @@ extension SpaceHelper {
             print("SpaceHelper: switchToSpace check. Live ID: \(liveCurrentSpaceID), Target: \(spaceID)")
         }
 
+        return makeSpaceSwitchContext(
+            state: state,
+            targetSpace: targetSpace,
+            liveCurrentSpaceID: liveCurrentSpaceID
+        )
+    }
+
+    private static func makeSpaceSwitchContext(
+        state: (spaces: [DesktopSpace], currentUUID: String, displayID: String),
+        targetSpace: DesktopSpace,
+        liveCurrentSpaceID: String?
+    ) -> SpaceSwitchContext {
+
         let currentSpaceIsFullscreen = state.spaces
             .first(where: { $0.id == liveCurrentSpaceID })?.isFullscreen ?? false
         let displaySpaces = state.spaces
@@ -127,7 +213,7 @@ extension SpaceHelper {
         let steps: Int?
         if let liveCurrentSpaceID,
            let currentIndex = displaySpaces.firstIndex(where: { $0.id == liveCurrentSpaceID }),
-           let targetIndex = displaySpaces.firstIndex(where: { $0.id == spaceID }) {
+           let targetIndex = displaySpaces.firstIndex(where: { $0.id == targetSpace.id }) {
             steps = targetIndex - currentIndex
         } else {
             steps = nil
@@ -188,17 +274,6 @@ extension SpaceHelper {
         lastProgrammaticTargetSpaceID = spaceID
         lastProgrammaticSwitchUsedSLS = false
 
-        // Prepare only the dedicated active label for the destination. Preview
-        // labels still follow the existing hideWhenSwitching behavior.
-        NotificationCenter.default.post(
-            name: NSNotification.Name("SpaceSwitchTargetRequested"),
-            object: nil,
-            userInfo: ["spaceID": spaceID]
-        )
-
-        NotificationCenter.default.post(
-            name: NSNotification.Name("SpaceSwitchRequested"), object: nil)
-
         // Gesture-based Space Switch handling. Keep the synthetic desktop
         // gesture as the primary path for fullscreen transitions too; the
         // WindowServer accepts it in the normal case and preserves the
@@ -233,6 +308,8 @@ extension SpaceHelper {
                     attempt: 1
                 )
             }
+            scheduleSpaceSwitchLabelSuppression(generation: generation)
+            scheduleActiveLabelPreparation(spaceID: spaceID, generation: generation)
             return .started
         }
 
@@ -262,6 +339,8 @@ extension SpaceHelper {
                         displayID: displayID,
                         isFullscreen: context.targetIsFullscreen
                     )
+                    scheduleSpaceSwitchLabelSuppression(generation: generation)
+                    scheduleActiveLabelPreparation(spaceID: spaceID, generation: generation)
                     return .started
                 }
             } else if let localNum = context.targetNum {
@@ -275,6 +354,8 @@ extension SpaceHelper {
                         displayID: displayID,
                         isFullscreen: context.targetIsFullscreen
                     )
+                    scheduleSpaceSwitchLabelSuppression(generation: generation)
+                    scheduleActiveLabelPreparation(spaceID: spaceID, generation: generation)
                     return .started
                 }
             }
@@ -310,6 +391,8 @@ extension SpaceHelper {
                     }
                 }
             }
+            scheduleSpaceSwitchLabelSuppression(generation: generation)
+            scheduleActiveLabelPreparation(spaceID: spaceID, generation: generation)
             return .started
         }
 
@@ -325,6 +408,52 @@ extension SpaceHelper {
             "switch request unavailable after transaction start: generation=\(generation.map(String.init) ?? "instant"), target=\(spaceID)"
         )
         return .unavailable
+    }
+
+    private static func scheduleSpaceSwitchLabelSuppression(generation: UInt64?) {
+        let suppress = {
+            NotificationCenter.default.post(
+                name: NSNotification.Name("SpaceSwitchRequested"),
+                object: nil
+            )
+        }
+
+        // Synthetic events must be posted before preview-window work. An
+        // instant operation has no event to protect, so keep its existing
+        // synchronous notification behavior.
+        if generation == nil {
+            suppress()
+        } else {
+            DispatchQueue.main.async(execute: suppress)
+        }
+    }
+
+    private static func scheduleActiveLabelPreparation(spaceID: String, generation: UInt64?) {
+        let prepare = {
+            if let generation {
+                guard let active = switchTransactionCoordinator.active,
+                      isSwitching,
+                      active.generation == generation,
+                      active.request.spaceID == spaceID else {
+                    return
+                }
+            }
+
+            NotificationCenter.default.post(
+                name: NSNotification.Name("SpaceSwitchTargetRequested"),
+                object: nil,
+                userInfo: ["spaceID": spaceID]
+            )
+        }
+
+        // The synthetic gesture must reach WindowServer before the active
+        // label performs its layout/binding work. Force-instant operations do
+        // not have a gesture to protect, so preserve their immediate behavior.
+        if generation == nil {
+            prepare()
+        } else {
+            DispatchQueue.main.async(execute: prepare)
+        }
     }
 
     private static func markProgrammaticSwitchStarted(

--- a/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceHelper/SpaceHelperSwitching.swift
@@ -249,6 +249,8 @@ extension SpaceHelper {
             isSwitching = false
             programmaticSwitchDestinationObserved = false
             programmaticSwitchNotificationObserved = false
+            programmaticSwitchUsesExtendedSettle = false
+            programmaticSwitchFastFollowUpRequested = false
         } else {
             let newGeneration = switchTransactionCoordinator.begin(
                 spaceID: spaceID,
@@ -258,6 +260,9 @@ extension SpaceHelper {
             isSwitching = true
             programmaticSwitchDestinationObserved = false
             programmaticSwitchNotificationObserved = false
+            programmaticSwitchUsesExtendedSettle =
+                context.targetIsFullscreen || context.currentSpaceIsFullscreen
+            programmaticSwitchFastFollowUpRequested = false
             programmaticSwitchCompletionWorkItem?.cancel()
             programmaticSwitchCompletionWorkItem = nil
             programmaticSwitchTimeoutWorkItem?.cancel()
@@ -506,6 +511,8 @@ extension SpaceHelper {
             isSwitching = false
             programmaticSwitchDestinationObserved = false
             programmaticSwitchNotificationObserved = false
+            programmaticSwitchUsesExtendedSettle = false
+            programmaticSwitchFastFollowUpRequested = false
             programmaticSwitchCompletionWorkItem?.cancel()
             programmaticSwitchCompletionWorkItem = nil
             programmaticSwitchTimeoutWorkItem?.cancel()
@@ -530,6 +537,8 @@ extension SpaceHelper {
         isSwitching = false
         programmaticSwitchDestinationObserved = false
         programmaticSwitchNotificationObserved = false
+        programmaticSwitchUsesExtendedSettle = false
+        programmaticSwitchFastFollowUpRequested = false
         lastProgrammaticSwitchTime = 0
         lastProgrammaticTargetSpaceID = nil
         lastProgrammaticSwitchUsedSLS = false
@@ -598,6 +607,32 @@ extension SpaceHelper {
         finishProgrammaticSwitch(at: active.request.spaceID, generation: active.generation)
     }
 
+    /// Requests faster serialization for a genuinely new trackpad gesture.
+    /// Fullscreen transitions keep their longer settle interval because Dock
+    /// can transiently expose their destination before focus is stable.
+    static func requestFastFollowUpSwitch() {
+        guard let active = switchTransactionCoordinator.active,
+              isSwitching,
+              !programmaticSwitchUsesExtendedSettle else {
+            return
+        }
+
+        programmaticSwitchFastFollowUpRequested = true
+        guard programmaticSwitchDestinationObserved else { return }
+
+        programmaticSwitchCompletionWorkItem?.cancel()
+        programmaticSwitchCompletionWorkItem = nil
+        DiagnosticEventLog.shared.record(
+            subsystem: "SpaceHelper",
+            level: "info",
+            "accelerating verified switch settle for follow-up gesture: generation=\(active.generation), target=\(active.request.spaceID)"
+        )
+        finishProgrammaticSwitch(
+            at: active.request.spaceID,
+            generation: active.generation
+        )
+    }
+
     private static func finishProgrammaticSwitch(at spaceID: String, generation: UInt64) {
         guard programmaticSwitchCompletionWorkItem == nil else { return }
 
@@ -605,6 +640,10 @@ extension SpaceHelper {
         // swipe has finished. Keep the transition open for one settling
         // interval, then verify the authoritative live state again before
         // releasing queued requests and restoring labels.
+        let settleDelay: TimeInterval =
+            programmaticSwitchFastFollowUpRequested && !programmaticSwitchUsesExtendedSettle
+            ? 0.08
+            : 0.35
         let workItem = DispatchWorkItem {
             guard let active = switchTransactionCoordinator.active,
                   isSwitching,
@@ -635,7 +674,7 @@ extension SpaceHelper {
             )
         }
         programmaticSwitchCompletionWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: workItem)
+        DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay, execute: workItem)
     }
 
     private static func scheduleProgrammaticSwitchCompletionVerification(
@@ -679,6 +718,8 @@ extension SpaceHelper {
         isSwitching = false
         programmaticSwitchDestinationObserved = false
         programmaticSwitchNotificationObserved = false
+        programmaticSwitchUsesExtendedSettle = false
+        programmaticSwitchFastFollowUpRequested = false
 
         switch reason {
         case .confirmed:

--- a/DesktopRenamer/Services/Space/SpaceLabelManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceLabelManager.swift
@@ -94,6 +94,9 @@ class SpaceLabelManager: ObservableObject {
     var delayedRestoreWorkItem: DispatchWorkItem?
     var previewTransitionRestoreWorkItem: DispatchWorkItem?
     var activeSyncWorkItems: [DispatchWorkItem] = []
+    var lastActiveVisibilitySpaceIDs: Set<String>?
+    var lastActiveVisibilityWindowIDs: Set<String> = []
+    var lastActiveVisibilityDisplayID: String?
     var reloadWorkItem: DispatchWorkItem?
     var workspaceSpaceChangeObserver: NSObjectProtocol?
     var workspaceApplicationActivationObserver: NSObjectProtocol?
@@ -104,6 +107,9 @@ class SpaceLabelManager: ObservableObject {
     var knownSpaceIDs: Set<String> = []
     var knownFullscreenSpaceIDs: Set<String> = []
     var lastKnownVisibleSpaceIDs: Set<String> = []
+    var lastLiveFullscreenVisibleSpaceIDs: Set<String> = []
+    var lastLiveFullscreenDisplayIDs: Set<String> = []
+    var lastLiveFullscreenDisplayScope: String?
     var previewLabelsSuppressedUntil: Date?
     var previewTransitionGeneration = 0
     var previewTransitionRestoreAttempt = 0

--- a/DesktopRenamer/Services/Space/SpaceLabelManager/SpaceLabelManagerWindows.swift
+++ b/DesktopRenamer/Services/Space/SpaceLabelManager/SpaceLabelManagerWindows.swift
@@ -166,7 +166,11 @@ extension SpaceLabelManager {
         if Thread.isMainThread {
             beginPreviewSuppressionForSwitchRequest()
         } else {
-            DispatchQueue.main.sync { [weak self] in
+            // GestureManager posts this from the multitouch callback. Queue
+            // the suppression without blocking that callback; the gesture's
+            // subsequent main-queue switch request is enqueued after this
+            // notification, so preview hiding still happens first.
+            DispatchQueue.main.async { [weak self] in
                 self?.beginPreviewSuppressionForSwitchRequest()
             }
         }
@@ -522,6 +526,10 @@ extension SpaceLabelManager {
         guard let spaceManager = spaceManager else { return }
         let allSpaces = spaceManager.spaceNameDict
 
+        // Window creation/removal changes the set covered by the active-label
+        // cache, even when the visible-space set remains unchanged.
+        lastActiveVisibilitySpaceIDs = nil
+
         // Add windows for new spaces.
         for space in allSpaces {
             ensureWindow(for: space.id, name: space.customName, displayID: space.displayID, updateMode: updateModes)
@@ -659,7 +667,35 @@ extension SpaceLabelManager {
 
     private func updateActiveWindowModes() {
         let visibleUUIDs = SpaceHelper.getVisibleSystemSpaceIDs()
-        for (key, window) in activeWindows {
+        updateActiveWindowModes(for: visibleUUIDs)
+    }
+
+    private func updateActiveWindowModes(
+        for visibleUUIDs: Set<String>,
+        displayID: String? = nil,
+        force: Bool = false
+    ) {
+        let eligibleWindows = activeWindows.filter {
+            displayID == nil || $0.value.displayID == displayID
+        }
+        let windowIDs = Set(eligibleWindows.keys)
+        let currentLabelNeedsRepair = showActiveLabels
+            && eligibleWindows.contains { key, window in
+                visibleUUIDs.contains(key)
+                    && (!window.isCurrentSpaceLabel || !window.isVisible)
+            }
+        guard force
+            || lastActiveVisibilitySpaceIDs != visibleUUIDs
+            || lastActiveVisibilityWindowIDs != windowIDs
+            || lastActiveVisibilityDisplayID != displayID
+            || currentLabelNeedsRepair else {
+            return
+        }
+
+        lastActiveVisibilitySpaceIDs = visibleUUIDs
+        lastActiveVisibilityWindowIDs = windowIDs
+        lastActiveVisibilityDisplayID = displayID
+        for (key, window) in eligibleWindows {
             window.setActiveVisibility(visibleUUIDs.contains(key), animated: false)
         }
     }
@@ -692,11 +728,17 @@ extension SpaceLabelManager {
              print("SpaceLabelManager: applyVisibility(visibleUUIDs: \(visibleUUIDs)) GLOBAL refresh")
         }
 
-        let fullscreenDisplayIDs = currentFullscreenDisplayIDs(
-            visibleUUIDs: visibleUUIDs,
-            displayID: displayID
-        )
         let suppressPreviews = hideWhenSwitching && isPreviewTransitionSuppressed
+        // During a transition every preview is hidden regardless of fullscreen
+        // metadata. Avoid another synchronous managed-space read on this hot
+        // path; the stable refresh below still rechecks fullscreen metadata
+        // when previews are allowed to return.
+        let fullscreenDisplayIDs = suppressPreviews
+            ? []
+            : currentFullscreenDisplayIDs(
+                visibleUUIDs: visibleUUIDs,
+                displayID: displayID
+            )
         let windowsSnapshot = self.createdWindows
 
         for (key, window) in windowsSnapshot {
@@ -712,16 +754,11 @@ extension SpaceLabelManager {
                 // the active desktop or over a fullscreen app.
                 window.hideImmediately()
             } else {
-                window.updateVisibility(animated: false)
+                window.updateVisibility(animated: false, visibleSpaceIDs: visibleUUIDs)
             }
         }
 
-        for (key, window) in activeWindows {
-            if let targetDisplay = displayID, window.displayID != targetDisplay {
-                continue
-            }
-            window.setActiveVisibility(visibleUUIDs.contains(key), animated: false)
-        }
+        updateActiveWindowModes(for: visibleUUIDs, displayID: displayID)
     }
 
     private func currentFullscreenDisplayIDs(
@@ -741,12 +778,16 @@ extension SpaceLabelManager {
             }
         )
 
-        // Fullscreen metadata can lag behind the managed-space ID during the
-        // enter/exit animation. Use the live state as a fallback so existing
-        // previews are not exposed while WindowServer is still transitioning.
-        if let liveState = SpaceHelper.getSystemState() {
-            fullscreenDisplayIDs.formUnion(
-                Set<String>(liveState.spaces.compactMap { space in
+        // Fullscreen metadata can lag behind the managed-space ID. Refresh the
+        // live fallback only when the visible-space set changes; repeated label
+        // refreshes during one transition can otherwise perform the same CGS
+        // read once per window.
+        if visibleUUIDs != lastLiveFullscreenVisibleSpaceIDs
+            || displayID != lastLiveFullscreenDisplayScope {
+            lastLiveFullscreenVisibleSpaceIDs = visibleUUIDs
+            lastLiveFullscreenDisplayScope = displayID
+            if let liveState = SpaceHelper.getSystemState() {
+                lastLiveFullscreenDisplayIDs = Set<String>(liveState.spaces.compactMap { space in
                     guard space.isFullscreen,
                           visibleUUIDs.contains(space.id),
                           displayID == nil || displayID == space.displayID else {
@@ -754,9 +795,12 @@ extension SpaceLabelManager {
                     }
                     return space.displayID
                 })
-            )
+            } else {
+                lastLiveFullscreenDisplayIDs = []
+            }
         }
 
+        fullscreenDisplayIDs.formUnion(lastLiveFullscreenDisplayIDs)
         return fullscreenDisplayIDs
     }
 

--- a/DesktopRenamer/Services/Space/SpaceManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager.swift
@@ -145,10 +145,10 @@ class SpaceManager: ObservableObject {
         }
         
 
+        MainActor.assumeIsolated {
+            self.spaceAPI?.setupListener()
+        }
         if SpaceManager.isAPIEnabled {
-            MainActor.assumeIsolated {
-                self.spaceAPI?.setupListener()
-            }
             DistributedNotificationCenter.default().postNotificationName(SpaceAPI.apiToggleNotification, object: nil, userInfo: ["isEnabled": true], deliverImmediately: true)
         }
         

--- a/DesktopRenamer/Services/Space/SpaceManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager.swift
@@ -63,6 +63,12 @@ class SpaceManager: ObservableObject {
     var spaceChangeRetryGeneration = 0
     var spaceChangeRetryObservedSpaceID: String?
     var spaceChangeRetryObservedPasses = 0
+    // Monitor notifications can arrive in bursts while WindowServer is
+    // settling a gesture. Keep only the newest observation and give the
+    // gesture transaction a chance to emit before reconciling the model.
+    var pendingMonitorSpaceChange: (rawUUID: String, isDesktop: Bool, ncCount: Int, displayID: String)?
+    var monitorSpaceChangeWorkItem: DispatchWorkItem?
+    var monitorSpaceChangeGeneration = 0
     var screenParametersWorkItem: DispatchWorkItem?
     
     // Display Cache
@@ -211,6 +217,7 @@ class SpaceManager: ObservableObject {
     deinit {
         wakeRecoveryWorkItem?.cancel()
         spaceChangeRetryWorkItem?.cancel()
+        monitorSpaceChangeWorkItem?.cancel()
         screenParametersWorkItem?.cancel()
         if Thread.isMainThread {
             SpaceHelper.stopMonitoring()
@@ -253,6 +260,7 @@ class SpaceManager: ObservableObject {
         isSystemSleeping = true
         wakeRecoveryWorkItem?.cancel()
         wakeRecoveryWorkItem = nil
+        cancelPendingMonitorSpaceChange()
         cancelSpaceChangeRetry()
         stopPeriodicSpaceLayoutCheck()
         SpaceHelper.stopMonitoring()

--- a/DesktopRenamer/Services/Space/SpaceManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager.swift
@@ -61,6 +61,8 @@ class SpaceManager: ObservableObject {
     let maxSpaceChangeRetries: Int = 5
     var spaceChangeRetryWorkItem: DispatchWorkItem?
     var spaceChangeRetryGeneration = 0
+    var spaceChangeRetryObservedSpaceID: String?
+    var spaceChangeRetryObservedPasses = 0
     var screenParametersWorkItem: DispatchWorkItem?
     
     // Display Cache
@@ -81,6 +83,7 @@ class SpaceManager: ObservableObject {
     @Published var movedWindowsOriginalSpaces: [Int: (originalSpaceUUID: String, currentSpaceUUID: String, pid: Int32)] = [:]
     var lastManualSwitchTime: TimeInterval = 0
     var lastManualSwitchTargetUUID: String? = nil
+    var activeProgrammaticSwitchGeneration: UInt64?
     
     @Published var returnToOriginalAfterBatchMove: Bool {
         didSet {
@@ -160,6 +163,13 @@ class SpaceManager: ObservableObject {
             self,
             selector: #selector(handleProgrammaticSwitchStarted(_:)),
             name: NSNotification.Name("SpaceProgrammaticSwitchStarted"),
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleProgrammaticSwitchFinished(_:)),
+            name: NSNotification.Name("SpaceProgrammaticSwitchFinished"),
             object: nil
         )
         

--- a/DesktopRenamer/Services/Space/SpaceManager.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager.swift
@@ -10,6 +10,7 @@ class SpaceManager: ObservableObject {
     static let spacesKey = "com.michaelqiu.desktoprenamer.spaces"
     static let nameCacheKey = "com.michaelqiu.desktoprenamer.namecache"
     static let indexCacheKey = "com.michaelqiu.desktoprenamer.indexcache"
+    static let bootSessionKey = "com.michaelqiu.desktoprenamer.namecache.bootsession"
     static let isAPIEnabledKey = "com.michaelqiu.desktoprenamer.isapienabled"
     static let grabOffsetXKey = "com.michaelqiu.desktoprenamer.grabOffsetX"
     static let grabOffsetYKey = "com.michaelqiu.desktoprenamer.grabOffsetY"
@@ -38,6 +39,8 @@ class SpaceManager: ObservableObject {
     
     var nameCache: [String: String] = [:]
     var indexCache: [String: String] = [:]
+    var currentBootSessionID: String?
+    var shouldRestoreNamesByPositionAfterBoot = false
     
     @Published var currentNcCount: Int = 0
     @Published var currentIsDesktop: Bool = false

--- a/DesktopRenamer/Services/Space/SpaceManager/Naming.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Naming.swift
@@ -66,10 +66,18 @@ extension SpaceManager {
                     
                     if trimmedName.isEmpty {
                         nameCache.removeValue(forKey: spaceUUID)
+                        if let persistentID = space.persistentID {
+                            nameCache.removeValue(
+                                forKey: Self.persistentNameCacheKey(for: persistentID)
+                            )
+                        }
                         indexCache.removeValue(forKey: indexKey)
                         indexCache.removeValue(forKey: legacyIndexKey)
                     } else {
                         nameCache[spaceUUID] = trimmedName
+                        if let persistentID = space.persistentID {
+                            nameCache[Self.persistentNameCacheKey(for: persistentID)] = trimmedName
+                        }
                         indexCache[indexKey] = trimmedName
                     }
                 }

--- a/DesktopRenamer/Services/Space/SpaceManager/Persistence.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Persistence.swift
@@ -1,9 +1,31 @@
 import AppKit
+import Darwin.sys.sysctl
 import Foundation
 import SwiftUI
 import WidgetKit
 
 extension SpaceManager {
+
+    static let persistentNameCachePrefix = "PersistentSpace|"
+
+    static func persistentNameCacheKey(for persistentID: String) -> String {
+        persistentNameCachePrefix + persistentID.uppercased()
+    }
+
+    private static func readBootSessionID() -> String? {
+        var size = 0
+        guard sysctlbyname("kern.bootsessionuuid", nil, &size, nil, 0) == 0,
+              size > 1 else {
+            return nil
+        }
+
+        var value = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("kern.bootsessionuuid", &value, &size, nil, 0) == 0 else {
+            return nil
+        }
+        let sessionID = String(cString: value).trimmingCharacters(in: .whitespacesAndNewlines)
+        return sessionID.isEmpty ? nil : sessionID.uppercased()
+    }
 
     // MARK: - Periodic Space Layout Check
 
@@ -83,6 +105,11 @@ extension SpaceManager {
     }
     
     func loadSavedData() {
+        currentBootSessionID = Self.readBootSessionID()
+        let savedBootSessionID = UserDefaults.standard.string(forKey: SpaceManager.bootSessionKey)
+        shouldRestoreNamesByPositionAfterBoot = currentBootSessionID != nil
+            && currentBootSessionID != savedBootSessionID?.uppercased()
+
         if let data = UserDefaults.standard.data(forKey: SpaceManager.spacesKey),
            let spaces = try? JSONDecoder().decode([DesktopSpace].self, from: data) {
             spaceNameDict = spaces.map {
@@ -148,5 +175,32 @@ extension SpaceManager {
         if let data = try? JSONEncoder().encode(indexCache) {
             UserDefaults.standard.set(data, forKey: SpaceManager.indexCacheKey)
         }
+    }
+
+    func completeBootNameMigration(using spaces: [DesktopSpace]) {
+        guard shouldRestoreNamesByPositionAfterBoot else { return }
+
+        // Numeric ManagedSpaceIDs from the previous boot are unsafe. Preserve
+        // durable UUID entries and rebuild the numeric aliases from the names
+        // that were just reconciled against the new boot's space list.
+        var rebuiltCache = nameCache.filter {
+            $0.key.hasPrefix(Self.persistentNameCachePrefix)
+        }
+        for space in spaces where !space.isFullscreen && !space.customName.isEmpty {
+            rebuiltCache[space.id] = space.customName
+            if let persistentID = space.persistentID {
+                rebuiltCache[Self.persistentNameCacheKey(for: persistentID)] = space.customName
+            }
+        }
+        nameCache = rebuiltCache
+        shouldRestoreNamesByPositionAfterBoot = false
+        if let currentBootSessionID {
+            UserDefaults.standard.set(currentBootSessionID, forKey: SpaceManager.bootSessionKey)
+        }
+        DiagnosticEventLog.shared.record(
+            subsystem: "SpaceManager",
+            level: "info",
+            "Rebuilt space-name identity cache for the current boot session"
+        )
     }
 }

--- a/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
@@ -31,6 +31,95 @@ extension SpaceManager {
         return true
     }
 
+    /// A regular gesture changes only the current managed space. When the
+    /// WindowServer space topology is unchanged, rebuilding names, publishing
+    /// the full space array, and refreshing every label is unnecessary work on
+    /// the main thread. Fullscreen entry/exit and space creation still take the
+    /// normal reconciliation path because their topology differs.
+    private func hasSameSpaceTopology(as detectedSpaces: [DesktopSpace]) -> Bool {
+        guard spaceNameDict.count == detectedSpaces.count else { return false }
+
+        var cachedByID: [String: DesktopSpace] = [:]
+        for cachedSpace in spaceNameDict {
+            guard cachedByID.updateValue(cachedSpace, forKey: cachedSpace.id) == nil else {
+                return false
+            }
+        }
+        guard cachedByID.count == detectedSpaces.count else { return false }
+
+        return detectedSpaces.allSatisfy { detected in
+            guard let cached = cachedByID[detected.id] else { return false }
+            return cached.num == detected.num
+                && cached.displayID == detected.displayID
+                && cached.isFullscreen == detected.isFullscreen
+                && cached.appName == detected.appName
+                && cached.appPath == detected.appPath
+                && cached.globalShortcutNum == detected.globalShortcutNum
+        }
+    }
+
+    /// Applies only the current-space fields for an in-flight transaction when
+    /// its managed-space topology is already known to be stable.
+    private func applyStableProgrammaticObservation(
+        _ cgsState: (spaces: [DesktopSpace], currentUUID: String, displayID: String),
+        ncCount: Int,
+        source: String
+    ) -> Bool {
+        guard SpaceHelper.isSwitching,
+              SpaceHelper.activeProgrammaticSwitchTargetSpaceID == cgsState.currentUUID,
+              hasSameSpaceTopology(as: cgsState.spaces) else {
+            return false
+        }
+
+        let previousUUID = currentSpaceUUID
+        currentSpaceUUID = cgsState.currentUUID
+        currentRawSpaceUUID = cgsState.currentUUID
+        currentDisplayID = cgsState.displayID
+        currentNcCount = ncCount
+        currentSpaceByDisplay[cgsState.displayID] = cgsState.currentUUID
+        currentIsDesktop = !(spaceNameDict.first(where: { $0.id == cgsState.currentUUID })?.isFullscreen ?? false)
+
+        if previousUUID != cgsState.currentUUID {
+            print(
+                "SpaceManager: Fast-path current-space reconciliation "
+                    + previousUUID
+                    + " -> "
+                    + cgsState.currentUUID
+                    + " (source: "
+                    + source
+                    + ")"
+            )
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceManager",
+                level: "info",
+                "Fast-path current-space reconciliation: "
+                    + previousUUID
+                    + " -> "
+                    + cgsState.currentUUID
+                    + ", source="
+                    + source
+            )
+
+            let now = Date().timeIntervalSince1970
+            let isProgrammaticSLS = SpaceHelper.lastProgrammaticSwitchUsedSLS
+                && now - SpaceHelper.lastProgrammaticSwitchTime < 2.0
+                && cgsState.currentUUID == SpaceHelper.lastProgrammaticTargetSpaceID
+            if isProgrammaticSLS {
+                SpaceHelper.restoreFocusAfterSLSSwitch(
+                    spaceID: cgsState.currentUUID,
+                    immediate: true
+                )
+            }
+        }
+
+        // The compact path is used only for a matching transaction target, so
+        // this observation is also the earliest safe completion checkpoint.
+        SpaceHelper.markProgrammaticSwitchComplete(at: cgsState.currentUUID)
+        cancelSpaceChangeRetry()
+        scheduleWidgetUpdate()
+        return true
+    }
+
     func refreshConnectedDisplays() {
         self.connectedDisplayUUIDs = Set(SpaceHelper.getAllDisplayUUIDs().map { $0.uppercased() })
         // print("SpaceManager: Refreshed connected displays: \(connectedDisplayUUIDs)")
@@ -43,18 +132,44 @@ extension SpaceManager {
         }
     }
     
-    func handleSpaceChange(_ rawUUID: String, isDesktop: Bool, ncCount: Int, displayID: String, source: String) {
+    func handleSpaceChange(
+        _ rawUUID: String,
+        isDesktop: Bool,
+        ncCount: Int,
+        displayID: String,
+        source: String,
+        bypassMonitorCoalescing: Bool = false
+    ) {
         DiagnosticEventLog.shared.record(subsystem: "SpaceManager", level: "info", "handleSpaceChange(display=\(displayID), source=\(source))")
         if SpaceHelper.isDragging {
             SpaceHelper.signalSpaceSwitchComplete(arrivedAtSpaceID: rawUUID)
         }
         
         if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in self?.handleSpaceChange(rawUUID, isDesktop: isDesktop, ncCount: ncCount, displayID: displayID, source: source) }
+            DispatchQueue.main.async { [weak self] in
+                self?.handleSpaceChange(
+                    rawUUID,
+                    isDesktop: isDesktop,
+                    ncCount: ncCount,
+                    displayID: displayID,
+                    source: source,
+                    bypassMonitorCoalescing: bypassMonitorCoalescing
+                )
+            }
             return
         }
 
         guard !isSystemSleeping else { return }
+
+        if source == "Monitor" && !bypassMonitorCoalescing {
+            scheduleMonitorSpaceChange(
+                rawUUID: rawUUID,
+                isDesktop: isDesktop,
+                ncCount: ncCount,
+                displayID: displayID
+            )
+            return
+        }
 
         print("SpaceManager: handleSpaceChange(rawUUID: \(rawUUID), displayID: \(displayID), source: \(source))")
 
@@ -84,6 +199,14 @@ extension SpaceManager {
                     }
                     return
                 }
+            }
+
+            if applyStableProgrammaticObservation(
+                cgsState,
+                ncCount: ncCount,
+                source: source
+            ) {
+                return
             }
             
             // First, see which names are already taken by active UUIDs so we don't double-assign.
@@ -324,6 +447,56 @@ extension SpaceManager {
             }
 
         if shouldUpdateWidget { scheduleWidgetUpdate() }
+    }
+
+    private func scheduleMonitorSpaceChange(
+        rawUUID: String,
+        isDesktop: Bool,
+        ncCount: Int,
+        displayID: String
+    ) {
+        pendingMonitorSpaceChange = (rawUUID, isDesktop, ncCount, displayID)
+        guard monitorSpaceChangeWorkItem == nil else {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceManager",
+                level: "info",
+                "coalesced monitor observation: display=\(displayID)"
+            )
+            return
+        }
+
+        monitorSpaceChangeGeneration += 1
+        let generation = monitorSpaceChangeGeneration
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  generation == self.monitorSpaceChangeGeneration else {
+                return
+            }
+
+            self.monitorSpaceChangeWorkItem = nil
+            guard let pending = self.pendingMonitorSpaceChange else { return }
+            self.pendingMonitorSpaceChange = nil
+            self.handleSpaceChange(
+                pending.rawUUID,
+                isDesktop: pending.isDesktop,
+                ncCount: pending.ncCount,
+                displayID: pending.displayID,
+                source: "Monitor",
+                bypassMonitorCoalescing: true
+            )
+        }
+
+        monitorSpaceChangeWorkItem = workItem
+        // A single short run-loop interval absorbs duplicate WindowServer
+        // notifications but does not add a perceptible delay to a gesture.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.02, execute: workItem)
+    }
+
+    func cancelPendingMonitorSpaceChange() {
+        monitorSpaceChangeGeneration += 1
+        monitorSpaceChangeWorkItem?.cancel()
+        monitorSpaceChangeWorkItem = nil
+        pendingMonitorSpaceChange = nil
     }
 
     func scheduleSpaceChangeRetry() {

--- a/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
@@ -5,6 +5,32 @@ import WidgetKit
 
 extension SpaceManager {
 
+    /// WindowServer can briefly report a neighboring space while a synthetic
+    /// gesture is still settling. The transaction coordinator is authoritative
+    /// during that interval; a timestamp is not sufficient because the retry
+    /// window can outlive the manual-attribution window.
+    private func shouldIgnoreStaleTransactionObservation(_ observedSpaceID: String, source: String) -> Bool {
+        guard SpaceHelper.isSwitching,
+              let activeTargetSpaceID = SpaceHelper.activeProgrammaticSwitchTargetSpaceID,
+              observedSpaceID != activeTargetSpaceID else {
+            return false
+        }
+
+        let generation = SpaceHelper.activeProgrammaticSwitchGeneration.map(String.init) ?? "nil"
+        print("SpaceManager: Stale space \(observedSpaceID) detected during active switch to \(activeTargetSpaceID) (source: \(source)). Ignoring.")
+        DiagnosticEventLog.shared.record(
+            subsystem: "SpaceManager",
+            level: "info",
+            "Ignoring stale transaction observation: generation=\(generation), observed=\(observedSpaceID), target=\(activeTargetSpaceID), source=\(source)"
+        )
+
+        // Do not schedule a SpaceManager retry while the transaction is still
+        // active. The transaction's generation-scoped completion or timeout
+        // owns recovery; a retry created here can outlive the transaction and
+        // publish the stale observation that was just rejected.
+        return true
+    }
+
     func refreshConnectedDisplays() {
         self.connectedDisplayUUIDs = Set(SpaceHelper.getAllDisplayUUIDs().map { $0.uppercased() })
         // print("SpaceManager: Refreshed connected displays: \(connectedDisplayUUIDs)")
@@ -42,6 +68,10 @@ extension SpaceManager {
 
         let previousUUID = self.currentSpaceUUID
         let targetUUID = cgsState.currentUUID
+
+        if shouldIgnoreStaleTransactionObservation(targetUUID, source: source) {
+            return
+        }
             
         let now = Date().timeIntervalSince1970
             let isRecentManualSwitch = now - lastManualSwitchTime < 2.0
@@ -296,7 +326,7 @@ extension SpaceManager {
         if shouldUpdateWidget { scheduleWidgetUpdate() }
     }
 
-    private func scheduleSpaceChangeRetry() {
+    func scheduleSpaceChangeRetry() {
         guard !isSystemSleeping else { return }
         guard spaceChangeRetryCount < maxSpaceChangeRetries else { return }
         spaceChangeRetryWorkItem?.cancel()
@@ -320,12 +350,18 @@ extension SpaceManager {
         spaceChangeRetryWorkItem = nil
         spaceChangeRetryGeneration += 1
         spaceChangeRetryCount = 0
+        spaceChangeRetryObservedSpaceID = nil
+        spaceChangeRetryObservedPasses = 0
     }
 
     private func performRetryDetection() {
         guard !isSystemSleeping else { return }
         guard let cgsState = SpaceHelper.getSystemState() else {
             scheduleSpaceChangeRetry()
+            return
+        }
+
+        if shouldIgnoreStaleTransactionObservation(cgsState.currentUUID, source: "Retry") {
             return
         }
 
@@ -342,6 +378,34 @@ extension SpaceManager {
                 subsystem: "SpaceManager",
                 level: "info",
                 "Ignoring inconsistent space retry: current=\(cgsState.currentUUID), visible=\(visibleSpaceIDs.sorted())"
+            )
+            scheduleSpaceChangeRetry()
+            return
+        }
+
+        if let independentlyObservedSpaceID = SpaceHelper.getCurrentSpaceID(for: cgsState.displayID),
+           independentlyObservedSpaceID != cgsState.currentUUID {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceManager",
+                level: "info",
+                "Ignoring inconsistent space retry read: state=\(cgsState.currentUUID), independent=\(independentlyObservedSpaceID), display=\(cgsState.displayID)"
+            )
+            scheduleSpaceChangeRetry()
+            return
+        }
+
+        if spaceChangeRetryObservedSpaceID == cgsState.currentUUID {
+            spaceChangeRetryObservedPasses += 1
+        } else {
+            spaceChangeRetryObservedSpaceID = cgsState.currentUUID
+            spaceChangeRetryObservedPasses = 1
+        }
+
+        guard spaceChangeRetryObservedPasses >= 2 else {
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceManager",
+                level: "info",
+                "Waiting for stable space retry candidate: current=\(cgsState.currentUUID), pass=\(spaceChangeRetryObservedPasses)/2"
             )
             scheduleSpaceChangeRetry()
             return

--- a/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
@@ -55,6 +55,7 @@ extension SpaceManager {
                 && cached.appName == detected.appName
                 && cached.appPath == detected.appPath
                 && cached.globalShortcutNum == detected.globalShortcutNum
+                && cached.persistentID == detected.persistentID
         }
     }
 
@@ -211,10 +212,14 @@ extension SpaceManager {
             
             // First, see which names are already taken by active UUIDs so we don't double-assign.
             var claimedNames: Set<String> = []
-            let activeUUIDs = Set(cgsState.spaces.map { $0.id })
-            
-            for (uuid, name) in nameCache {
-                if activeUUIDs.contains(uuid) && !name.isEmpty {
+            for space in cgsState.spaces where !space.isFullscreen {
+                if let persistentID = space.persistentID,
+                   let name = nameCache[Self.persistentNameCacheKey(for: persistentID)],
+                   !name.isEmpty {
+                    claimedNames.insert(name)
+                } else if !shouldRestoreNamesByPositionAfterBoot,
+                          let name = nameCache[space.id],
+                          !name.isEmpty {
                     claimedNames.insert(name)
                 }
             }
@@ -246,24 +251,43 @@ extension SpaceManager {
                     let dIndex = spaceDesktopIndices[sysSpace.id] ?? 1
                     let indexKey = "\(finalSpace.displayID)|Desktop|\(dIndex)"
                     let legacyIndexKey = "\(finalSpace.displayID)|\(finalSpace.num)"
-                    
-                    if let cachedName = nameCache[sysSpace.id], !cachedName.isEmpty {
-                        finalSpace.customName = cachedName
-                    } else {
-                        if let fallbackName = indexCache[indexKey], !fallbackName.isEmpty {
-                            if !claimedNames.contains(fallbackName) {
-                                finalSpace.customName = fallbackName
-                            }
-                        } else if let fallbackName = indexCache[legacyIndexKey], !fallbackName.isEmpty {
-                            if !claimedNames.contains(fallbackName) {
-                                finalSpace.customName = fallbackName
-                            }
-                        } else if let existing = spaceNameDict.first(where: { $0.id == sysSpace.id }), !existing.customName.isEmpty {
-                            finalSpace.customName = existing.customName
-                            nameCache[sysSpace.id] = existing.customName
-                            if indexCache[indexKey]?.isEmpty ?? true {
-                                indexCache[indexKey] = existing.customName
-                            }
+
+                    let persistentName = finalSpace.persistentID.flatMap {
+                        nameCache[Self.persistentNameCacheKey(for: $0)]
+                    }
+                    let positionalName = indexCache[indexKey]
+                    let legacyPositionalName = indexCache[legacyIndexKey]
+                    let managedIDName = shouldRestoreNamesByPositionAfterBoot
+                        ? nil
+                        : nameCache[sysSpace.id]
+
+                    if let persistentName, !persistentName.isEmpty {
+                        finalSpace.customName = persistentName
+                    } else if let managedIDName, !managedIDName.isEmpty {
+                        finalSpace.customName = managedIDName
+                    } else if let positionalName,
+                              !positionalName.isEmpty,
+                              !claimedNames.contains(positionalName) {
+                        finalSpace.customName = positionalName
+                    } else if let legacyPositionalName,
+                              !legacyPositionalName.isEmpty,
+                              !claimedNames.contains(legacyPositionalName) {
+                        finalSpace.customName = legacyPositionalName
+                    } else if !shouldRestoreNamesByPositionAfterBoot,
+                              let existing = spaceNameDict.first(where: { $0.id == sysSpace.id }),
+                              !existing.customName.isEmpty {
+                        finalSpace.customName = existing.customName
+                    }
+
+                    if !finalSpace.customName.isEmpty {
+                        claimedNames.insert(finalSpace.customName)
+                        nameCache[finalSpace.id] = finalSpace.customName
+                        if let persistentID = finalSpace.persistentID {
+                            nameCache[Self.persistentNameCacheKey(for: persistentID)] =
+                                finalSpace.customName
+                        }
+                        if indexCache[indexKey]?.isEmpty ?? true {
+                            indexCache[indexKey] = finalSpace.customName
                         }
                     }
                 }
@@ -323,9 +347,13 @@ extension SpaceManager {
                 )
             }
 
-            if self.spaceNameDict != newSpaceList {
+            let completesBootNameMigration = shouldRestoreNamesByPositionAfterBoot
+            let spaceListChanged = self.spaceNameDict != newSpaceList
+            if spaceListChanged {
                 self.spaceNameDict = newSpaceList
-                
+            }
+
+            if spaceListChanged || completesBootNameMigration {
                 // Refresh missing index entries only. CGS can briefly report a
                 // reordered space list after reboot, so automatic detection must
                 // not replace explicit desktop-position names.
@@ -341,7 +369,10 @@ extension SpaceManager {
                         }
                     }
                 }
-                
+
+                if completesBootNameMigration {
+                    completeBootNameMigration(using: self.spaceNameDict)
+                }
                 saveData()
                 shouldUpdateWidget = true
             }

--- a/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/Reconciliation.swift
@@ -512,7 +512,7 @@ extension SpaceManager {
         let workItem = DispatchWorkItem { [weak self] in
             guard let self = self,
                   generation == self.spaceChangeRetryGeneration else { return }
-            self.performRetryDetection()
+            self.performRetryDetection(generation: generation)
         }
         spaceChangeRetryWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
@@ -527,12 +527,18 @@ extension SpaceManager {
         spaceChangeRetryObservedPasses = 0
     }
 
-    private func performRetryDetection() {
-        guard !isSystemSleeping else { return }
+    private func performRetryDetection(generation: Int) {
+        guard !isSystemSleeping,
+              generation == spaceChangeRetryGeneration else { return }
         guard let cgsState = SpaceHelper.getSystemState() else {
             scheduleSpaceChangeRetry()
             return
         }
+
+        // A WindowServer query may overlap a newer monitor observation or a
+        // newly started switch. Cancellation cannot stop a work item that is
+        // already executing, so reject its result again after the read.
+        guard generation == spaceChangeRetryGeneration else { return }
 
         if shouldIgnoreStaleTransactionObservation(cgsState.currentUUID, source: "Retry") {
             return
@@ -545,6 +551,7 @@ extension SpaceManager {
         // disagree; accepting the older snapshot would move the model back to
         // the source space and reopen its preview label.
         let visibleSpaceIDs = SpaceHelper.getVisibleSystemSpaceIDs()
+        guard generation == spaceChangeRetryGeneration else { return }
         guard !visibleSpaceIDs.isEmpty,
               visibleSpaceIDs.contains(cgsState.currentUUID) else {
             DiagnosticEventLog.shared.record(
@@ -556,7 +563,9 @@ extension SpaceManager {
             return
         }
 
-        if let independentlyObservedSpaceID = SpaceHelper.getCurrentSpaceID(for: cgsState.displayID),
+        let independentlyObservedSpaceID = SpaceHelper.getCurrentSpaceID(for: cgsState.displayID)
+        guard generation == spaceChangeRetryGeneration else { return }
+        if let independentlyObservedSpaceID,
            independentlyObservedSpaceID != cgsState.currentUUID {
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceManager",
@@ -583,6 +592,10 @@ extension SpaceManager {
             scheduleSpaceChangeRetry()
             return
         }
+
+        // Do not let an old retry commit after a transaction-start observer or
+        // a newer retry chain invalidated it during the stability checks.
+        guard generation == spaceChangeRetryGeneration else { return }
 
         let now = Date().timeIntervalSince1970
         let isRecentManualSwitch = now - lastManualSwitchTime < 2.0

--- a/DesktopRenamer/Services/Space/SpaceManager/SpaceManagerSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/SpaceManagerSwitching.swift
@@ -21,9 +21,12 @@ extension SpaceManager {
         )
 
         // A monitor retry may have been scheduled from an earlier stale
-        // snapshot. Cancel it only after a real switch starts; a queued request
-        // must leave the active transaction's verification retry intact.
+        // snapshot. Cancel it after a real switch starts or a request is
+        // rejected; a queued request must leave the active transaction's
+        // verification retry intact.
         if case .started = disposition {
+            cancelSpaceChangeRetry()
+        } else if case .unavailable = disposition {
             cancelSpaceChangeRetry()
         }
         return disposition
@@ -37,6 +40,14 @@ extension SpaceManager {
         let update = { [weak self] in
             guard let self else { return }
             let isManual = notification.userInfo?["isManual"] as? Bool == true
+            let generation = notification.userInfo?["generation"] as? UInt64
+
+            // This notification also arrives for a transaction promoted from
+            // the pending queue. Cancel any retry belonging to the previous
+            // transition before the new generation can be observed.
+            self.cancelSpaceChangeRetry()
+            self.activeProgrammaticSwitchGeneration = generation
+
             if isManual {
                 self.lastManualSwitchTime = Date().timeIntervalSince1970
                 self.lastManualSwitchTargetUUID = spaceID
@@ -46,11 +57,52 @@ extension SpaceManager {
                 self.lastManualSwitchTime = 0
                 self.lastManualSwitchTargetUUID = nil
             }
-            let generation = notification.userInfo?["generation"] as? UInt64
             DiagnosticEventLog.shared.record(
                 subsystem: "SpaceManager",
                 level: "info",
                 "programmatic switch transaction started: target=\(spaceID), manual=\(isManual), generation=\(generation.map(String.init) ?? "instant")"
+            )
+        }
+
+        if Thread.isMainThread {
+            update()
+        } else {
+            DispatchQueue.main.async(execute: update)
+        }
+    }
+
+    @objc func handleProgrammaticSwitchFinished(_ notification: Notification) {
+        guard let generation = notification.userInfo?["generation"] as? UInt64,
+              let confirmed = notification.userInfo?["confirmed"] as? Bool else {
+            return
+        }
+
+        let update = { [weak self] in
+            guard let self else { return }
+
+            guard self.activeProgrammaticSwitchGeneration == generation else {
+                DiagnosticEventLog.shared.record(
+                    subsystem: "SpaceManager",
+                    level: "info",
+                    "Ignoring stale programmatic switch completion: generation=\(generation), active=\(self.activeProgrammaticSwitchGeneration.map(String.init) ?? "nil")"
+                )
+                return
+            }
+
+            // A retry scheduled from a transaction is no longer allowed to
+            // publish its old WindowServer snapshot after that transaction has
+            // ended. A timed-out transaction gets a new, unassociated retry
+            // chain below so a genuine destination change is still recovered.
+            self.activeProgrammaticSwitchGeneration = nil
+            self.cancelSpaceChangeRetry()
+            if !confirmed {
+                self.scheduleSpaceChangeRetry()
+            }
+
+            DiagnosticEventLog.shared.record(
+                subsystem: "SpaceManager",
+                level: confirmed ? "info" : "warning",
+                "programmatic switch finished: generation=\(generation), confirmed=\(confirmed), retry chain reset"
             )
         }
 

--- a/DesktopRenamer/Services/Space/SpaceManager/SpaceManagerSwitching.swift
+++ b/DesktopRenamer/Services/Space/SpaceManager/SpaceManagerSwitching.swift
@@ -45,6 +45,7 @@ extension SpaceManager {
             // This notification also arrives for a transaction promoted from
             // the pending queue. Cancel any retry belonging to the previous
             // transition before the new generation can be observed.
+            self.cancelPendingMonitorSpaceChange()
             self.cancelSpaceChangeRetry()
             self.activeProgrammaticSwitchGeneration = generation
 
@@ -113,18 +114,38 @@ extension SpaceManager {
         }
     }
     
-    func switchToPreviousSpace(onDisplayID displayID: String? = nil, forceInstant: Bool? = nil) {
+    @discardableResult
+    func switchToPreviousSpace(
+        onDisplayID displayID: String? = nil,
+        forceInstant: Bool? = nil
+    ) -> SpaceSwitchRequestDisposition {
         let targetDisplayID = displayID ?? spaceNameDict.first(where: { $0.id == currentSpaceUUID })?.displayID ?? currentDisplayID
-        if let current = findBestCurrentSpace(for: targetDisplayID) {
-            proceedToSwitch(from: current, on: targetDisplayID, direction: -1, forceInstant: forceInstant ?? false)
+        guard let current = findBestCurrentSpace(for: targetDisplayID) else {
+            return .unavailable
         }
+        return proceedToSwitch(
+            from: current,
+            on: targetDisplayID,
+            direction: -1,
+            forceInstant: forceInstant ?? false
+        )
     }
 
-    func switchToNextSpace(onDisplayID displayID: String? = nil, forceInstant: Bool? = nil) {
+    @discardableResult
+    func switchToNextSpace(
+        onDisplayID displayID: String? = nil,
+        forceInstant: Bool? = nil
+    ) -> SpaceSwitchRequestDisposition {
         let targetDisplayID = displayID ?? spaceNameDict.first(where: { $0.id == currentSpaceUUID })?.displayID ?? currentDisplayID
-        if let current = findBestCurrentSpace(for: targetDisplayID) {
-            proceedToSwitch(from: current, on: targetDisplayID, direction: 1, forceInstant: forceInstant ?? false)
+        guard let current = findBestCurrentSpace(for: targetDisplayID) else {
+            return .unavailable
         }
+        return proceedToSwitch(
+            from: current,
+            on: targetDisplayID,
+            direction: 1,
+            forceInstant: forceInstant ?? false
+        )
     }
 
     private func findBestCurrentSpace(for displayID: String) -> DesktopSpace? {
@@ -151,18 +172,28 @@ extension SpaceManager {
         return spaceNameDict.first(where: { $0.displayID == displayID })
     }
 
-    private func proceedToSwitch(from current: DesktopSpace, on targetDisplayID: String, direction: Int, forceInstant: Bool = false) {
+    @discardableResult
+    private func proceedToSwitch(
+        from current: DesktopSpace,
+        on targetDisplayID: String,
+        direction: Int,
+        forceInstant: Bool = false
+    ) -> SpaceSwitchRequestDisposition {
         // Use spaces from the TARGET display
         let displaySpaces = spaceNameDict
             .filter { $0.displayID == targetDisplayID }
             .sorted { $0.num < $1.num }
         
-        guard let currentIndex = displaySpaces.firstIndex(of: current) else { return }
+        guard let currentIndex = displaySpaces.firstIndex(of: current) else {
+            return .unavailable
+        }
         
         let targetIndex = currentIndex + direction
-        guard targetIndex >= 0 && targetIndex < displaySpaces.count else { return }
+        guard targetIndex >= 0 && targetIndex < displaySpaces.count else {
+            return .unavailable
+        }
         
         let target = displaySpaces[targetIndex]
-        switchToSpace(target, forceInstant: forceInstant)
+        return switchToSpace(target, forceInstant: forceInstant)
     }
 }

--- a/DesktopRenamer/Services/Switch/GestureCallbacks.swift
+++ b/DesktopRenamer/Services/Switch/GestureCallbacks.swift
@@ -18,10 +18,13 @@ func mtCallback(
 
     let typedPointer = touchPointer.assumingMemoryBound(to: MTTouch.self)
     let buffer = UnsafeBufferPointer(start: typedPointer, count: Int(numFingers))
-    let touches = Array(buffer)
 
     // Valid states: 1 (Hover/Range), 2 (Touching), 3 (Dragging), 4 (Lifting)
-    let validTouches = touches.filter { $0.state > 0 && $0.state < 7 }
+    var validTouches: [MTTouch] = []
+    validTouches.reserveCapacity(min(Int(numFingers), 4))
+    for touch in buffer where touch.state > 0 && touch.state < 7 {
+        validTouches.append(touch)
+    }
 
     if validTouches.count >= 3 {
         GestureManager.lastTrackpadSwipeTime = Date().timeIntervalSince1970
@@ -37,4 +40,3 @@ func mtCallback(
         manager.handleTouches(touches: [], numFingers: 0)
     }
 }
-

--- a/DesktopRenamer/Services/Switch/GestureManager.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager.swift
@@ -64,7 +64,7 @@ class GestureManager: ObservableObject {
     let kMoveWindowOnOption = "GestureManager.MoveWindowOnOption"
     let kSwitchDuration = "GestureManager.SwitchDuration"
 
-    public enum SwitchOverrideMode: String, CaseIterable, Identifiable {
+    public enum SwitchOverrideMode: String, CaseIterable, Identifiable, Equatable {
         case cursor = "Cursor"
         case activeWindow = "Active Window"
 
@@ -128,6 +128,39 @@ class GestureManager: ObservableObject {
     var lastTouchTime: TimeInterval = 0
     var lastSwitchTime: TimeInterval = 0
 
+    // The multitouch callback can outpace the main queue while WindowServer
+    // is reconciling a space. Keep the callback lightweight and allow only
+    // one main-queue action at a time. A later request replaces the pending
+    // direction and is resumed after the current SpaceHelper transaction is
+    // settled.
+    let gestureSwitchStateLock = NSLock()
+    var isGestureSwitchActionScheduled = false
+    var isGestureSwitchOperationInFlight = false
+    var isGestureSwitchTransactionActive = false
+    var pendingGestureSwitchDirection: SwitchDirection?
+    var gestureSwitchResumeWorkItem: DispatchWorkItem?
+    var programmaticSwitchFinishedObserver: NSObjectProtocol?
+
+    // Boundary checks are used only for the overscroll affordance. Cache the
+    // result during a short touch sequence instead of querying CGS for every
+    // multitouch frame, which can otherwise delay the actual switch request.
+    var cachedBoundaryDisplayID: String?
+    var cachedBoundaryDirection: SwitchDirection?
+    var cachedBoundaryMode: SwitchOverrideMode?
+    var cachedBoundaryValue = false
+    var cachedBoundaryTime: TimeInterval = 0
+    let boundaryCacheDuration: TimeInterval = 0.12
+    var boundaryRefreshWorkItem: DispatchWorkItem?
+    var boundaryRefreshGeneration = 0
+
+    // These values are written by the multitouch callback and are used to
+    // avoid enqueueing redundant overlay updates on the main queue.
+    var isOverscrollIndicatorActive = false
+    var lastOverscrollDirection: SwitchDirection?
+    var lastOverscrollProgress: Double = 0
+    var overscrollUpdateWorkItem: DispatchWorkItem?
+    var overscrollUpdateGeneration = 0
+
     // Gesture direction locking to prevent oscillation during a single swipe.
     var lockedDirection: SwitchDirection? = nil
 
@@ -169,6 +202,14 @@ class GestureManager: ObservableObject {
 
         GestureManager.sharedManager = self
 
+        programmaticSwitchFinishedObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("SpaceProgrammaticSwitchFinished"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.schedulePendingGestureSwitchResume()
+        }
+
         loadPrivateFramework()
 
         // Start monitoring always because we need it to intercept macOS switching gestures for hideWhenSwitching,
@@ -177,6 +218,12 @@ class GestureManager: ObservableObject {
     }
 
     deinit {
+        if let observer = programmaticSwitchFinishedObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        gestureSwitchResumeWorkItem?.cancel()
+        boundaryRefreshWorkItem?.cancel()
+        overscrollUpdateWorkItem?.cancel()
         stopMonitoring()
     }
 

--- a/DesktopRenamer/Services/Switch/GestureManager.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager.swift
@@ -127,6 +127,10 @@ class GestureManager: ObservableObject {
 
     var lastTouchTime: TimeInterval = 0
     var lastSwitchTime: TimeInterval = 0
+    // One physical contact session produces at most one switch. A quick
+    // follow-up remains possible, but only after every finger has left the
+    // trackpad and a new contact session begins.
+    var isWaitingForAllFingersToLift = false
 
     // The multitouch callback can outpace the main queue while WindowServer
     // is reconciling a space. Keep the callback lightweight and allow only
@@ -165,7 +169,7 @@ class GestureManager: ObservableObject {
     var lockedDirection: SwitchDirection? = nil
 
     // Sensitivity and timing configuration.
-    let switchCooldown: TimeInterval = 0.15
+    let switchCooldown: TimeInterval = 0.06
     // private let minSwipeDistance: Float = 0.10 // Moved to swipeThreshold
     let consistencyThreshold: Float = 0.01  // 5% Minimum movement per finger (Anti-Tap)
     let touchTimeout: TimeInterval = 0.15

--- a/DesktopRenamer/Services/Switch/GestureManager.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager.swift
@@ -153,7 +153,8 @@ class GestureManager: ObservableObject {
     var cachedBoundaryMode: SwitchOverrideMode?
     var cachedBoundaryValue = false
     var cachedBoundaryTime: TimeInterval = 0
-    let boundaryCacheDuration: TimeInterval = 0.12
+    let boundaryCacheDuration: TimeInterval = 0.5
+    let boundaryStateLock = NSLock()
     var boundaryRefreshWorkItem: DispatchWorkItem?
     var boundaryRefreshGeneration = 0
 

--- a/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
@@ -9,6 +9,17 @@ extension GestureManager {
     func handleTouches(touches: [MTTouch], numFingers: Int) {
         let now = Date().timeIntervalSince1970
 
+        if numFingers == 0 {
+            isWaitingForAllFingersToLift = false
+            resetTrackingState()
+            return
+        }
+
+        // After a recognized swipe, lifting only one or two fingers must not
+        // arm another switch. Wait for a frame with no active contacts so a
+        // long swipe cannot be mistaken for several independent gestures.
+        guard !isWaitingForAllFingersToLift else { return }
+
         // Timeout Check.
         if now - lastTouchTime > touchTimeout {
             resetTrackingState()
@@ -140,6 +151,7 @@ extension GestureManager {
                     // Only act if matches locked direction
                     if lockedDirection == direction {
                         print("GestureManager: Triggered \(direction)")
+                        isWaitingForAllFingersToLift = true
                         SpaceHelper.cancelPendingRawSpaceUUIDScan()
 
                         // Only perform the switch action if SwitchOverride is enabled AND finger count matches user preference
@@ -158,12 +170,10 @@ extension GestureManager {
                             triggerSwitch(direction: direction)
                         }
 
-                        // CRITICAL: Reset anchors to current position to allow consecutive swipes
+                        // A new switch is armed only by the zero-contact frame
+                        // at the start of handleTouches.
                         initialTouchPositions.removeAll()
-                        for touch in touches {
-                            initialTouchPositions[touch.identifier] =
-                                touch.normalizedVector.position
-                        }
+                        lockedDirection = nil
                         invalidateBoundaryCache()
                     }
                 }
@@ -346,6 +356,12 @@ extension GestureManager {
             "gesture switch request \(disposition): direction=\(direction), transactionActive=\(transactionActive)"
         )
 
+        if transactionActive {
+            DispatchQueue.main.async {
+                SpaceHelper.requestFastFollowUpSwitch()
+            }
+        }
+
         guard shouldSchedule else { return }
         let execute: () -> Void = { [weak self] in
             guard let self else { return }
@@ -448,6 +464,11 @@ extension GestureManager {
             level: "info",
             "gesture switch deferred by active transaction: direction=\(direction)"
         )
+        // This request can only come from a new contact session because the
+        // recognizer waits for all fingers to lift after each accepted swipe.
+        // Regular desktops can therefore finish their verified settle sooner;
+        // fullscreen transitions retain the conservative interval.
+        SpaceHelper.requestFastFollowUpSwitch()
         scheduleGestureSwitchResumeProbe()
     }
 

--- a/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
@@ -89,15 +89,28 @@ extension GestureManager {
             if abs(avgDX) > abs(avgDY) {
                 let direction: SwitchDirection = avgDX < 0 ? .next : .previous
 
-                // Boundary feedback is only useful near the trigger point.
-                // Avoid asking WindowServer for the current space on every
-                // early touch frame; that query runs on the private multitouch
-                // callback and can delay recognition of the actual switch.
+                // Start the asynchronous boundary lookup as soon as intent is
+                // clear, leaving enough time for it to finish before the
+                // gesture reaches the trigger threshold.
+                if abs(avgDX) >= consistencyThreshold {
+                    scheduleBoundaryRefresh(direction: direction, mode: switchOverride)
+                }
+
                 let isNearSwitchThreshold = abs(avgDX) >= swipeThreshold * 0.75
-                if isNearSwitchThreshold && isAtBoundary(for: direction, now: now) {
-                    isOverscroll = true
-                    let progress = Double(abs(avgDX) / swipeThreshold)
-                    updateOverscrollIndicator(progress: progress, direction: direction)
+                if isNearSwitchThreshold {
+                    switch boundaryStatus(for: direction, now: now) {
+                    case .boundary:
+                        isOverscroll = true
+                        let progress = Double(abs(avgDX) / swipeThreshold)
+                        updateOverscrollIndicator(progress: progress, direction: direction)
+                    case .unknown:
+                        // The actual switch also requires the main queue. Wait
+                        // for the already-scheduled lookup instead of treating
+                        // an unresolved edge as an available destination.
+                        return
+                    case .available:
+                        break
+                    }
                 }
             }
         }
@@ -189,13 +202,16 @@ extension GestureManager {
     }
 
     private func invalidateBoundaryCache() {
+        boundaryStateLock.lock()
         boundaryRefreshGeneration += 1
-        boundaryRefreshWorkItem?.cancel()
+        let workItem = boundaryRefreshWorkItem
         boundaryRefreshWorkItem = nil
         cachedBoundaryDisplayID = nil
         cachedBoundaryDirection = nil
         cachedBoundaryMode = nil
         cachedBoundaryTime = 0
+        boundaryStateLock.unlock()
+        workItem?.cancel()
     }
 
     enum SwitchDirection: Equatable {
@@ -203,14 +219,27 @@ extension GestureManager {
         case previous
     }
 
-    private func isAtBoundary(for direction: SwitchDirection, now: TimeInterval) -> Bool {
+    private enum BoundaryStatus {
+        case unknown
+        case boundary
+        case available
+    }
+
+    private func boundaryStatus(
+        for direction: SwitchDirection,
+        now: TimeInterval
+    ) -> BoundaryStatus {
         let mode = switchOverride
 
+        boundaryStateLock.lock()
         if cachedBoundaryDirection == direction,
            cachedBoundaryMode == mode,
            now - cachedBoundaryTime < boundaryCacheDuration {
-            return cachedBoundaryValue
+            let status: BoundaryStatus = cachedBoundaryValue ? .boundary : .available
+            boundaryStateLock.unlock()
+            return status
         }
+        boundaryStateLock.unlock()
 
         // The multitouch driver invokes handleTouches synchronously on its
         // callback thread. Do not call WindowServer or AppKit here: even one
@@ -219,23 +248,37 @@ extension GestureManager {
         // affordance on the main queue and let the real switch request decide
         // whether an adjacent space exists.
         scheduleBoundaryRefresh(direction: direction, mode: mode)
-        return false
+        return .unknown
     }
 
     private func scheduleBoundaryRefresh(
         direction: SwitchDirection,
         mode: SwitchOverrideMode
     ) {
-        guard boundaryRefreshWorkItem == nil else { return }
+        boundaryStateLock.lock()
+        let now = Date().timeIntervalSince1970
+        if cachedBoundaryDirection == direction,
+           cachedBoundaryMode == mode,
+           now - cachedBoundaryTime < boundaryCacheDuration {
+            boundaryStateLock.unlock()
+            return
+        }
+        guard boundaryRefreshWorkItem == nil else {
+            boundaryStateLock.unlock()
+            return
+        }
 
         let generation = boundaryRefreshGeneration
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
-            guard generation == self.boundaryRefreshGeneration else {
+            guard self.switchOverride == mode else {
+                self.boundaryStateLock.lock()
+                if generation == self.boundaryRefreshGeneration {
+                    self.boundaryRefreshWorkItem = nil
+                }
+                self.boundaryStateLock.unlock()
                 return
             }
-            self.boundaryRefreshWorkItem = nil
-            guard self.switchOverride == mode else { return }
 
             let targetDisplayID: String?
             if mode == .cursor {
@@ -253,16 +296,22 @@ extension GestureManager {
                 value = self.spaceManager?.isLastSpace(onDisplayID: targetDisplayID) == true
             }
 
+            self.boundaryStateLock.lock()
+            guard generation == self.boundaryRefreshGeneration else {
+                self.boundaryStateLock.unlock()
+                return
+            }
+            self.boundaryRefreshWorkItem = nil
             self.cachedBoundaryDirection = direction
             self.cachedBoundaryMode = mode
             self.cachedBoundaryValue = value
             self.cachedBoundaryTime = Date().timeIntervalSince1970
+            self.boundaryStateLock.unlock()
         }
 
         boundaryRefreshWorkItem = workItem
-        // Delay the optional boundary read by one short run-loop interval so a
-        // real gesture request already queued on main is emitted first.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: workItem)
+        boundaryStateLock.unlock()
+        DispatchQueue.main.async(execute: workItem)
     }
 
     private func updateOverscrollIndicator(progress: Double, direction: SwitchDirection) {

--- a/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
+++ b/DesktopRenamer/Services/Switch/GestureManager/Processing.swift
@@ -78,33 +78,15 @@ extension GestureManager {
             if abs(avgDX) > abs(avgDY) {
                 let direction: SwitchDirection = avgDX < 0 ? .next : .previous
 
-                // Determine target display to check boundaries
-                var targetDisplayID: String? = nil
-                if self.switchOverride == .cursor {
-                    targetDisplayID = SpaceHelper.getCursorDisplayID()
-                }
-                // If .activeWindow, we leave nil, relying on SpaceManager's default context
-
-                if direction == .previous {
-                    if spaceManager?.isFirstSpace(onDisplayID: targetDisplayID) == true {
-                        isOverscroll = true
-                        // avgDX is positive here.
-                        let progress = Double(abs(avgDX) / swipeThreshold)
-                        // Previous means going "Left". Wall is on Left. Edge is .leading.
-                        DispatchQueue.main.async {
-                            OverscrollOverlayManager.shared.update(progress: progress, edge: .leading)
-                        }
-                    }
-                } else {  // .next
-                    if spaceManager?.isLastSpace(onDisplayID: targetDisplayID) == true {
-                        isOverscroll = true
-                        // avgDX is negative here.
-                        let progress = Double(abs(avgDX) / swipeThreshold)
-                        // Next means going "Right". Wall is on Right. Edge is .trailing.
-                        DispatchQueue.main.async {
-                            OverscrollOverlayManager.shared.update(progress: progress, edge: .trailing)
-                        }
-                    }
+                // Boundary feedback is only useful near the trigger point.
+                // Avoid asking WindowServer for the current space on every
+                // early touch frame; that query runs on the private multitouch
+                // callback and can delay recognition of the actual switch.
+                let isNearSwitchThreshold = abs(avgDX) >= swipeThreshold * 0.75
+                if isNearSwitchThreshold && isAtBoundary(for: direction, now: now) {
+                    isOverscroll = true
+                    let progress = Double(abs(avgDX) / swipeThreshold)
+                    updateOverscrollIndicator(progress: progress, direction: direction)
                 }
             }
         }
@@ -112,9 +94,7 @@ extension GestureManager {
         if isOverscroll {
             return
         } else {
-            DispatchQueue.main.async {
-                OverscrollOverlayManager.shared.hide()
-            }
+            hideOverscrollIndicator()
         }
 
         // Trigger Logic.
@@ -160,15 +140,21 @@ extension GestureManager {
                     // Only act if matches locked direction
                     if lockedDirection == direction {
                         print("GestureManager: Triggered \(direction)")
-
-                        // Fire a nil-target SpaceSwitchRequested so SpaceLabelManager can hide all active Preview Labels.
-                        // SpaceHelper owns its programmatic-switch timestamp; the gesture marker must not
-                        // overwrite the active transaction's identity while WindowServer is settling.
-                        NotificationCenter.default.post(
-                            name: NSNotification.Name("SpaceSwitchRequested"), object: nil)
+                        SpaceHelper.cancelPendingRawSpaceUUIDScan()
 
                         // Only perform the switch action if SwitchOverride is enabled AND finger count matches user preference
-                        if numFingers == self.fingerCount && self.isEnabled {
+                        let performsSwitchOverride = numFingers == self.fingerCount && self.isEnabled
+
+                        // Native macOS gestures still need an early label-hide
+                        // notification. An overridden gesture hides previews
+                        // at the actual SpaceHelper transaction boundary,
+                        // avoiding a duplicate main-queue suppression pass.
+                        if !performsSwitchOverride {
+                            NotificationCenter.default.post(
+                                name: NSNotification.Name("SpaceSwitchRequested"), object: nil)
+                        }
+
+                        if performsSwitchOverride {
                             triggerSwitch(direction: direction)
                         }
 
@@ -178,6 +164,7 @@ extension GestureManager {
                             initialTouchPositions[touch.identifier] =
                                 touch.normalizedVector.position
                         }
+                        invalidateBoundaryCache()
                     }
                 }
             }
@@ -187,49 +174,379 @@ extension GestureManager {
     func resetTrackingState() {
         initialTouchPositions.removeAll()
         lockedDirection = nil
-
-        DispatchQueue.main.async {
-            OverscrollOverlayManager.shared.hide()
-        }
+        invalidateBoundaryCache()
+        hideOverscrollIndicator()
     }
 
-    enum SwitchDirection {
+    private func invalidateBoundaryCache() {
+        boundaryRefreshGeneration += 1
+        boundaryRefreshWorkItem?.cancel()
+        boundaryRefreshWorkItem = nil
+        cachedBoundaryDisplayID = nil
+        cachedBoundaryDirection = nil
+        cachedBoundaryMode = nil
+        cachedBoundaryTime = 0
+    }
+
+    enum SwitchDirection: Equatable {
         case next
         case previous
     }
 
+    private func isAtBoundary(for direction: SwitchDirection, now: TimeInterval) -> Bool {
+        let mode = switchOverride
+
+        if cachedBoundaryDirection == direction,
+           cachedBoundaryMode == mode,
+           now - cachedBoundaryTime < boundaryCacheDuration {
+            return cachedBoundaryValue
+        }
+
+        // The multitouch driver invokes handleTouches synchronously on its
+        // callback thread. Do not call WindowServer or AppKit here: even one
+        // boundary query can stall the callback immediately before the swipe
+        // crosses the trigger threshold. Refresh the optional overscroll
+        // affordance on the main queue and let the real switch request decide
+        // whether an adjacent space exists.
+        scheduleBoundaryRefresh(direction: direction, mode: mode)
+        return false
+    }
+
+    private func scheduleBoundaryRefresh(
+        direction: SwitchDirection,
+        mode: SwitchOverrideMode
+    ) {
+        guard boundaryRefreshWorkItem == nil else { return }
+
+        let generation = boundaryRefreshGeneration
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard generation == self.boundaryRefreshGeneration else {
+                return
+            }
+            self.boundaryRefreshWorkItem = nil
+            guard self.switchOverride == mode else { return }
+
+            let targetDisplayID: String?
+            if mode == .cursor {
+                let displayID = SpaceHelper.getCursorDisplayID()
+                self.cachedBoundaryDisplayID = displayID
+                targetDisplayID = displayID
+            } else {
+                targetDisplayID = nil
+            }
+
+            let value: Bool
+            if direction == .previous {
+                value = self.spaceManager?.isFirstSpace(onDisplayID: targetDisplayID) == true
+            } else {
+                value = self.spaceManager?.isLastSpace(onDisplayID: targetDisplayID) == true
+            }
+
+            self.cachedBoundaryDirection = direction
+            self.cachedBoundaryMode = mode
+            self.cachedBoundaryValue = value
+            self.cachedBoundaryTime = Date().timeIntervalSince1970
+        }
+
+        boundaryRefreshWorkItem = workItem
+        // Delay the optional boundary read by one short run-loop interval so a
+        // real gesture request already queued on main is emitted first.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08, execute: workItem)
+    }
+
+    private func updateOverscrollIndicator(progress: Double, direction: SwitchDirection) {
+        let progressChanged = !isOverscrollIndicatorActive
+            || lastOverscrollDirection != direction
+            || abs(progress - lastOverscrollProgress) >= 0.04
+        guard progressChanged else { return }
+
+        isOverscrollIndicatorActive = true
+        lastOverscrollDirection = direction
+        lastOverscrollProgress = progress
+        let edge: OverscrollIndicatorView.Edge = direction == .previous ? .leading : .trailing
+        overscrollUpdateGeneration += 1
+        let generation = overscrollUpdateGeneration
+        overscrollUpdateWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  generation == self.overscrollUpdateGeneration,
+                  self.isOverscrollIndicatorActive else {
+                return
+            }
+            self.overscrollUpdateWorkItem = nil
+            OverscrollOverlayManager.shared.update(progress: progress, edge: edge)
+        }
+        overscrollUpdateWorkItem = workItem
+        DispatchQueue.main.async(execute: workItem)
+    }
+
+    private func hideOverscrollIndicator() {
+        guard isOverscrollIndicatorActive else { return }
+        isOverscrollIndicatorActive = false
+        lastOverscrollDirection = nil
+        lastOverscrollProgress = 0
+        overscrollUpdateGeneration += 1
+        let generation = overscrollUpdateGeneration
+        overscrollUpdateWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  generation == self.overscrollUpdateGeneration else {
+                return
+            }
+            self.overscrollUpdateWorkItem = nil
+            OverscrollOverlayManager.shared.hide()
+        }
+        overscrollUpdateWorkItem = workItem
+        DispatchQueue.main.async(execute: workItem)
+    }
+
     func triggerSwitch(direction: SwitchDirection) {
-        DiagnosticEventLog.shared.record(subsystem: "GestureManager", level: "info", "triggerSwitch(\(direction))")
+        DiagnosticEventLog.shared.record(
+            subsystem: "GestureManager",
+            level: "info",
+            "triggerSwitch(\(direction))"
+        )
         lastSwitchTime = Date().timeIntervalSince1970
-        guard let sm = spaceManager, self.isEnabled else { return }
+        guard spaceManager != nil, self.isEnabled else { return }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+        enqueueGestureSwitchRequest(direction)
+    }
 
-            let isHoldingOption = NSEvent.modifierFlags.contains(.option)
-            if self.moveWindowOnOption && isHoldingOption {
-                // If the current space is a fullscreen app, just exit fullscreen.
-                if sm.spaceNameDict.first(where: { $0.id == sm.currentSpaceUUID })?.isFullscreen == true {
-                    Task { @MainActor in
-                        await Self.exitFullscreen()
-                    }
-                } else {
-                    switch direction {
-                    case .next:
-                        sm.moveActiveWindowToNextSpace()
-                    case .previous:
-                        sm.moveActiveWindowToPreviousSpace()
-                    }
+    private func enqueueGestureSwitchRequest(_ direction: SwitchDirection) {
+        var shouldSchedule = false
+        let disposition: String
+        let transactionActive: Bool
+
+        gestureSwitchStateLock.lock()
+        if isGestureSwitchActionScheduled
+            || isGestureSwitchOperationInFlight
+            || isGestureSwitchTransactionActive {
+            let previousDirection = pendingGestureSwitchDirection
+            pendingGestureSwitchDirection = direction
+            if let previousDirection, previousDirection == direction {
+                disposition = "coalesced duplicate"
+            } else if let previousDirection {
+                disposition = "replaced pending \(previousDirection)"
+            } else {
+                disposition = "queued"
+            }
+            transactionActive = isGestureSwitchTransactionActive
+        } else {
+            isGestureSwitchActionScheduled = true
+            shouldSchedule = true
+            disposition = "scheduled"
+            transactionActive = false
+        }
+        gestureSwitchStateLock.unlock()
+
+        DiagnosticEventLog.shared.record(
+            subsystem: "GestureManager",
+            level: "info",
+            "gesture switch request \(disposition): direction=\(direction), transactionActive=\(transactionActive)"
+        )
+
+        guard shouldSchedule else { return }
+        let execute: () -> Void = { [weak self] in
+            guard let self else { return }
+            self.performScheduledGestureSwitch(initialDirection: direction)
+        }
+
+        // The multitouch callback is delivered by the private driver on a
+        // worker thread. Never block that callback while the main thread is
+        // reconciling WindowServer state. The gate preserves ordering and
+        // coalesces any additional directions before this work item runs.
+        if Thread.isMainThread {
+            execute()
+        } else {
+            DispatchQueue.main.async(execute: execute)
+        }
+    }
+
+    private func performScheduledGestureSwitch(initialDirection: SwitchDirection) {
+        guard let direction = takeScheduledGestureDirection(initialDirection) else {
+            return
+        }
+
+        guard let sm = spaceManager, self.isEnabled else {
+            completeGestureSwitchOperation(transactionStarted: false)
+            return
+        }
+
+        let isHoldingOption = NSEvent.modifierFlags.contains(.option)
+        if moveWindowOnOption && isHoldingOption {
+            // Window moves and fullscreen exit have their own asynchronous
+            // cleanup and do not emit SpaceProgrammaticSwitchFinished.
+            // Keep them outside the serialized space-switch gate.
+            if sm.spaceNameDict.first(where: { $0.id == sm.currentSpaceUUID })?.isFullscreen == true {
+                Task { @MainActor in
+                    await Self.exitFullscreen()
                 }
             } else {
-                let targetDisplayID = (self.switchOverride == .cursor) ? SpaceHelper.getCursorDisplayID() : nil
                 switch direction {
                 case .next:
-                    sm.switchToNextSpace(onDisplayID: targetDisplayID)
+                    sm.moveActiveWindowToNextSpace()
                 case .previous:
-                    sm.switchToPreviousSpace(onDisplayID: targetDisplayID)
+                    sm.moveActiveWindowToPreviousSpace()
                 }
             }
+            completeGestureSwitchOperation(transactionStarted: false)
+            return
+        }
+
+        // Avoid doing the expensive adjacent-space lookup while another
+        // transaction is settling. The direction is retained and resolved
+        // against the live space only after promotion has completed.
+        if SpaceHelper.isSwitching {
+            retainGestureSwitchForActiveTransaction(direction)
+            return
+        }
+
+        let targetDisplayID = (switchOverride == .cursor) ? SpaceHelper.getCursorDisplayID() : nil
+        let step = direction == .next ? 1 : -1
+        let disposition = SpaceHelper.switchToAdjacentSpace(
+            direction: step,
+            onDisplayID: targetDisplayID,
+            isManual: true
+        )
+
+        let transactionStarted = disposition == .started || disposition == .queued
+        DiagnosticEventLog.shared.record(
+            subsystem: "GestureManager",
+            level: "info",
+            "gesture switch executed: direction=\(direction), disposition=\(disposition), transactionStarted=\(transactionStarted)"
+        )
+        completeGestureSwitchOperation(transactionStarted: transactionStarted)
+    }
+
+    private func takeScheduledGestureDirection(_ initialDirection: SwitchDirection) -> SwitchDirection? {
+        gestureSwitchStateLock.lock()
+        guard isGestureSwitchActionScheduled else {
+            gestureSwitchStateLock.unlock()
+            return nil
+        }
+
+        isGestureSwitchActionScheduled = false
+        isGestureSwitchOperationInFlight = true
+        let direction = pendingGestureSwitchDirection ?? initialDirection
+        pendingGestureSwitchDirection = nil
+        gestureSwitchStateLock.unlock()
+        return direction
+    }
+
+    private func retainGestureSwitchForActiveTransaction(_ direction: SwitchDirection) {
+        gestureSwitchStateLock.lock()
+        isGestureSwitchOperationInFlight = false
+        isGestureSwitchTransactionActive = true
+        if pendingGestureSwitchDirection == nil {
+            pendingGestureSwitchDirection = direction
+        }
+        gestureSwitchStateLock.unlock()
+
+        DiagnosticEventLog.shared.record(
+            subsystem: "GestureManager",
+            level: "info",
+            "gesture switch deferred by active transaction: direction=\(direction)"
+        )
+        scheduleGestureSwitchResumeProbe()
+    }
+
+    private func completeGestureSwitchOperation(transactionStarted: Bool) {
+        var nextDirection: SwitchDirection?
+
+        gestureSwitchStateLock.lock()
+        isGestureSwitchOperationInFlight = false
+        isGestureSwitchTransactionActive = transactionStarted
+
+        if !transactionStarted,
+           !isGestureSwitchActionScheduled,
+           let pendingDirection = pendingGestureSwitchDirection {
+            pendingGestureSwitchDirection = nil
+            isGestureSwitchActionScheduled = true
+            nextDirection = pendingDirection
+        }
+        gestureSwitchStateLock.unlock()
+
+        if transactionStarted {
+            scheduleGestureSwitchResumeProbe()
+        } else if let nextDirection {
+            DiagnosticEventLog.shared.record(
+                subsystem: "GestureManager",
+                level: "info",
+                "resuming pending gesture switch after \(transactionStarted ? "transaction" : "rejected request"): direction=\(nextDirection)"
+            )
+            DispatchQueue.main.async { [weak self] in
+                self?.performScheduledGestureSwitch(initialDirection: nextDirection)
+            }
+        } else {
+            gestureSwitchResumeWorkItem?.cancel()
+            gestureSwitchResumeWorkItem = nil
+        }
+    }
+
+    func schedulePendingGestureSwitchResume() {
+        // The completion notification is posted before SpaceHelper promotes
+        // its own pending destination. Two main-queue turns put this check
+        // after that promotion without adding a fixed delay to the switch.
+        DispatchQueue.main.async { [weak self] in
+            DispatchQueue.main.async { [weak self] in
+                self?.resumePendingGestureSwitchIfPossible()
+            }
+        }
+    }
+
+    private func scheduleGestureSwitchResumeProbe() {
+        gestureSwitchResumeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.resumePendingGestureSwitchIfPossible()
+        }
+        gestureSwitchResumeWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15, execute: workItem)
+    }
+
+    private func resumePendingGestureSwitchIfPossible() {
+        guard !SpaceHelper.isSwitching,
+              !SpaceHelper.isProgrammaticSwitchPromotionPending else {
+            scheduleGestureSwitchResumeProbe()
+            return
+        }
+
+        var nextDirection: SwitchDirection?
+        gestureSwitchStateLock.lock()
+        guard isGestureSwitchTransactionActive,
+              !isGestureSwitchActionScheduled,
+              !isGestureSwitchOperationInFlight else {
+            gestureSwitchStateLock.unlock()
+            return
+        }
+
+        isGestureSwitchTransactionActive = false
+        if let pendingDirection = pendingGestureSwitchDirection {
+            pendingGestureSwitchDirection = nil
+            isGestureSwitchActionScheduled = true
+            nextDirection = pendingDirection
+        }
+        gestureSwitchStateLock.unlock()
+
+        gestureSwitchResumeWorkItem?.cancel()
+        gestureSwitchResumeWorkItem = nil
+
+        guard let nextDirection else {
+            DiagnosticEventLog.shared.record(
+                subsystem: "GestureManager",
+                level: "info",
+                "gesture switch gate idle: no pending direction"
+            )
+            return
+        }
+
+        DiagnosticEventLog.shared.record(
+            subsystem: "GestureManager",
+            level: "info",
+            "promoting pending gesture direction: direction=\(nextDirection)"
+        )
+        DispatchQueue.main.async { [weak self] in
+            self?.performScheduledGestureSwitch(initialDirection: nextDirection)
         }
     }
 

--- a/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Appearance.swift
+++ b/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Appearance.swift
@@ -45,7 +45,6 @@ extension SpaceLabelWindow {
         syncFromGlobalState()
         updateLayout(isCurrentSpace: true, updateFrame: false)
         updateVisibility(animated: animated)
-        bindToTargetSpace()
     }
 
     func setPreviewSize(_ size: NSSize) {

--- a/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Interaction.swift
+++ b/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Interaction.swift
@@ -10,6 +10,8 @@ extension SpaceLabelWindow {
     }
 
     func hideImmediately() {
+        let wasVisible = isVisible
+
         // A preview may have a delayed retry queued from the switch cooldown.
         // Cancel it before hiding so the retry cannot reveal the preview again
         // after the manager has determined that this is the current space.
@@ -29,7 +31,9 @@ extension SpaceLabelWindow {
         // Ordering it out removes that frame without changing its assigned
         // Space; updateVisibility() orders it back in when the preview is
         // allowed to show again.
-        self.orderOut(nil)
+        if wasVisible {
+            self.orderOut(nil)
+        }
     }
 
     // Interaction handling for mouse events.

--- a/DesktopRenamer/Views/Overlays/SpaceLabelWindow/State.swift
+++ b/DesktopRenamer/Views/Overlays/SpaceLabelWindow/State.swift
@@ -30,11 +30,18 @@ extension SpaceLabelWindow {
 
         let winID = [NSNumber(value: self.windowNumber)] as CFArray
         let targetSpaces = [NSNumber(value: targetSpaceInt)] as CFArray
-
-        CGSAddWindowsToSpaces(cid, winID, targetSpaces)
-
         let currentSpacesCF = CGSCopySpacesForWindows(cid, 7, winID)
         let currentSpaces = (currentSpacesCF as? [NSNumber])?.map { $0.intValue } ?? []
+
+        // Rebinding an already-correct label is a synchronous WindowServer
+        // operation. Visibility and active-label synchronization can call
+        // this method several times during one transition, so avoid changing
+        // the window's space assignment when there is nothing to repair.
+        if currentSpaces == [targetSpaceInt] {
+            return
+        }
+
+        CGSAddWindowsToSpaces(cid, winID, targetSpaces)
 
         print("SpaceLabelWindow[\(self.spaceId)]: bindToTargetSpace. Window Number: \(self.windowNumber). Current spaces: \(currentSpaces). Target space: \(targetSpaceInt)")
         DiagnosticEventLog.shared.record(subsystem: "SpaceLabelWindow", "bindToTargetSpace[\(self.spaceId)]: win=\(self.windowNumber), currentSpaces=\(currentSpaces), target=\(targetSpaceInt)")

--- a/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Visibility.swift
+++ b/DesktopRenamer/Views/Overlays/SpaceLabelWindow/Visibility.swift
@@ -4,7 +4,7 @@ import QuartzCore
 
 extension SpaceLabelWindow {
 
-    func updateVisibility(animated: Bool) {
+    func updateVisibility(animated: Bool, visibleSpaceIDs: Set<String>? = nil) {
         pendingVisibilityTask?.cancel()
         pendingVisibilityTask = nil
 
@@ -39,7 +39,8 @@ extension SpaceLabelWindow {
         // SpaceLabelManager.applyVisibility. A delayed retry or an unrelated
         // appearance refresh can arrive after the manager hid the preview.
         // Preview labels must never be rendered on their current space.
-        if !isActiveMode && SpaceHelper.getVisibleSystemSpaceIDs().contains(spaceId) {
+        let knownVisibleSpaceIDs = visibleSpaceIDs ?? SpaceHelper.getVisibleSystemSpaceIDs()
+        if !isActiveMode && knownVisibleSpaceIDs.contains(spaceId) {
             hideImmediately()
             return
         }
@@ -55,6 +56,8 @@ extension SpaceLabelWindow {
         } else {
             isVisuallyVisible = labelManager?.showPreviewLabels ?? true
         }
+
+        var didBindToTargetSpace = false
         
         // hideWhenSwitching applies only to preview windows. Active labels have
         // dedicated windows and must remain synchronized with the active space.
@@ -92,6 +95,7 @@ extension SpaceLabelWindow {
                     print("SpaceLabelWindow[\(self.spaceId)]: orderFrontRegardless() for ACTIVE space.")
                     self.orderFront(nil)
                     self.bindToTargetSpace()
+                    didBindToTargetSpace = true
                     self.hasOrderedInOnce = true
                 }
             } else if !hasOrderedInOnce {
@@ -108,11 +112,13 @@ extension SpaceLabelWindow {
                         // Control is reconciling labels on macOS 27.
                         self.orderPreviewWithoutActivating()
                         self.bindToTargetSpace()
+                        didBindToTargetSpace = true
                         self.hasOrderedInOnce = true
                     } else {
                         print("SpaceLabelWindow[\(self.spaceId)]: Binding check failed — preview label would appear on wrong space. Staying hidden.")
                         DiagnosticEventLog.shared.record(subsystem: "SpaceLabelWindow", level: "warning", "BLOCKED orderFrontRegardless for preview label \(self.spaceId): bound=\(isBoundToTargetSpace()), onCurrent=\(isOnCurrentSpace())")
                         self.bindToTargetSpace()
+                        didBindToTargetSpace = true
                     }
                 } else {
                     print("SpaceLabelWindow[\(self.spaceId)]: Suppressing orderFrontRegardless (Preview) during switch cooling period (\(String(format: "%.2f", timeSinceSwitch))s). Scheduling retry.")
@@ -127,10 +133,12 @@ extension SpaceLabelWindow {
                         print("SpaceLabelWindow[\(self.spaceId)]: Non-activating orderFront() for background preview.")
                         self.orderPreviewWithoutActivating()
                         self.bindToTargetSpace()
+                        didBindToTargetSpace = true
                     } else {
                         print("SpaceLabelWindow[\(self.spaceId)]: Re-order blocked — preview label would appear on wrong space.")
                         DiagnosticEventLog.shared.record(subsystem: "SpaceLabelWindow", level: "warning", "BLOCKED re-order for preview label \(self.spaceId): bound=\(isBoundToTargetSpace()), onCurrent=\(isOnCurrentSpace())")
                         self.bindToTargetSpace()
+                        didBindToTargetSpace = true
                     }
                 } else {
                     scheduleVisibilityRetry(delay: coolingPeriod - timeSinceSwitch + 0.1)
@@ -138,7 +146,7 @@ extension SpaceLabelWindow {
             }
         }
 
-        if self.isVisible {
+        if self.isVisible && !didBindToTargetSpace {
             self.bindToTargetSpace()
         }
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,13 @@
+# SpaceAPI contract tests
+
+The project does not currently contain an Xcode test target. The Foundation-only
+contract harness can be compiled and run from the repository root with:
+
+```sh
+swiftc -swift-version 5 \
+    DesktopRenamer/Services/API/APIContract.swift \
+    DesktopRenamer/Services/API/SpaceAPILegacyFormat.swift \
+    Tests/SpaceAPIContractTests.swift \
+    -o /tmp/DesktopRenamerSpaceAPIContractTests
+/tmp/DesktopRenamerSpaceAPIContractTests
+```

--- a/Tests/SpaceAPIContractTests.swift
+++ b/Tests/SpaceAPIContractTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+@main
+struct SpaceAPIContractTests {
+    static func main() throws {
+        try testRequestRoundTripAndValidation()
+        try testResponseRoundTripAndUnknownFields()
+        try testEventRoundTrip()
+        try testLegacyFixtures()
+        print("SpaceAPI contract tests passed")
+    }
+
+    private static func testRequestRoundTripAndValidation() throws {
+        let request = SpaceAPIJSONRPCRequest(
+            id: "request-1",
+            method: "renameSpace",
+            params: [
+                "spaceID": .string("space|~\"\n测试"),
+                "name": .string("名称\nwith delimiters | ~")
+            ]
+        )
+        let payload = try SpaceAPIJSONRPCCodec.encode(request)
+        check(try SpaceAPIJSONRPCCodec.decodeRequest(payload) == request, "request round trip")
+
+        expectError(-32700, payload: "{", operation: SpaceAPIJSONRPCCodec.decodeRequest)
+        expectError(-32600, payload: "[]", operation: SpaceAPIJSONRPCCodec.decodeRequest)
+        expectError(
+            -32600,
+            payload: "{\"jsonrpc\":\"1.0\",\"id\":\"1\",\"method\":\"getAPIInfo\"}",
+            operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+        expectError(
+            -32600,
+            payload: "{\"jsonrpc\":\"2.0\",\"method\":\"getAPIInfo\"}",
+            operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+        expectError(
+            -32602,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"getAPIInfo\",\"params\":[]}",
+            operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+        expectError(
+            -32006,
+            payload: String(repeating: "x", count: DesktopRenamerAPIContract.maxPayloadBytes + 1),
+            operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+    }
+
+    private static func testResponseRoundTripAndUnknownFields() throws {
+        let space = SpaceAPISpace(
+            id: "space|~\"\n测试",
+            name: "名称\nwith delimiters | ~",
+            displayID: "display-1",
+            displayName: "主显示器",
+            number: 4,
+            isFullscreen: false,
+            appName: nil,
+            appPath: nil,
+            globalShortcutNumber: 4
+        )
+        let window = SpaceAPIWindow(
+            id: 123,
+            pid: 456,
+            ownerName: "Example | Owner",
+            appPath: nil,
+            title: nil,
+            spaceID: space.id,
+            isMinimized: false,
+            isHidden: true
+        )
+        let snapshot = SpaceAPISnapshot(
+            apiVersion: DesktopRenamerAPIContract.version,
+            revision: 42,
+            timestamp: "2026-08-31T00:00:00Z",
+            currentSpaceIDs: [space.id],
+            currentSpaceName: space.name,
+            spaces: [space]
+        )
+        let response = SpaceAPIJSONRPCResponse(
+            id: "request-2",
+            result: .object([
+                "snapshot": try SpaceAPIJSONValue.from(snapshot),
+                "windows": try SpaceAPIJSONValue.from([window])
+            ])
+        )
+        let payload = try SpaceAPIJSONRPCCodec.encode(response)
+        let decoded = try SpaceAPIJSONRPCCodec.decodeResponse(payload)
+        let decodedObject = try checkValue(decoded.result, "response result")
+        let decodedSnapshot = try checkValue(decodedObject.objectValue?["snapshot"], "snapshot result")
+            .decode(SpaceAPISnapshot.self)
+        check(decodedSnapshot == snapshot, "snapshot with nullable and delimiter fields")
+
+        let payloadObject = try JSONSerialization.jsonObject(with: Data(payload.utf8), options: [.fragmentsAllowed])
+        var jsonObject = try checkJSONObject(payloadObject)
+        var resultObject = try checkJSONObject(jsonObject["result"])
+        resultObject["futureField"] = ["ignored": true]
+        jsonObject["result"] = resultObject
+        let unknownFieldPayload = try jsonString(jsonObject)
+        let unknownFieldResponse = try SpaceAPIJSONRPCCodec.decodeResponse(unknownFieldPayload)
+        let unknownResult = try checkValue(unknownFieldResponse.result, "unknown-field result")
+        let compatibleSnapshot = try unknownResult.objectValue?["snapshot"]?.decode(SpaceAPISnapshot.self)
+        check(compatibleSnapshot == snapshot, "unknown result fields are ignored")
+
+        let error = SpaceAPIJSONRPCCodec.errorResponse(
+            id: "request-3",
+            code: -32602,
+            message: "Invalid parameter.",
+            data: SpaceAPIErrorData(parameter: "spaceID", expected: "string", command: "switchToSpace")
+        )
+        let errorPayload = try SpaceAPIJSONRPCCodec.encode(error)
+        let decodedError = try SpaceAPIJSONRPCCodec.decodeResponse(errorPayload)
+        check(decodedError.error?.code == -32602, "error code round trip")
+        let errorData = try decodedError.error?.data?.decode(SpaceAPIErrorData.self)
+        check(errorData?.parameter == "spaceID", "error metadata round trip")
+
+        expectError(
+            -32600,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{},\"error\":{\"code\":-1,\"message\":\"failed\"}}",
+            operation: SpaceAPIJSONRPCCodec.decodeResponse
+        )
+        expectError(
+            -32600,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\"}",
+            operation: SpaceAPIJSONRPCCodec.decodeResponse
+        )
+    }
+
+    private static func testEventRoundTrip() throws {
+        let event = SpaceAPIJSONRPCEvent(
+            method: "stateChanged",
+            params: .object([
+                "reason": .string("spaceListChanged"),
+                "revision": .number(9)
+            ])
+        )
+        let payload = try SpaceAPIJSONRPCCodec.encode(event)
+        check(try SpaceAPIJSONRPCCodec.decodeEvent(payload) == event, "event round trip")
+
+        expectError(
+            -32602,
+            payload: "{\"jsonrpc\":\"2.0\",\"method\":\"stateChanged\",\"params\":[]}",
+            operation: SpaceAPIJSONRPCCodec.decodeEvent
+        )
+    }
+
+    private static func testLegacyFixtures() throws {
+        let spaceLine = SpaceAPILegacyFormatter.spaceLine(
+            id: "4",
+            name: "Name|with~delimiters",
+            displayName: "Display",
+            number: 4,
+            isFullscreen: false,
+            appPath: "/Applications/Test.app"
+        )
+        check(
+            spaceLine == ">4~Name|with~delimiters~Display~4~0~/Applications/Test.app\n",
+            "legacy space fixture"
+        )
+
+        let windowLine = SpaceAPILegacyFormatter.windowLine(
+            id: 123,
+            pid: 456,
+            ownerName: "Owner|Name",
+            appPath: "/Applications/Test.app",
+            title: "Title~with\ntext",
+            isMinimized: true,
+            isHidden: false
+        )
+        check(
+            windowLine == "  123|456|Owner|Name|/Applications/Test.app|Title~with\ntext|1|0\n",
+            "legacy window fixture"
+        )
+    }
+
+    private static func expectError<T>(
+        _ code: Int,
+        payload: String,
+        operation: (String) throws -> T
+    ) {
+        do {
+            _ = try operation(payload)
+            fail("expected error \(code)")
+        } catch let error as SpaceAPIContractError {
+            check(error.jsonRPCCode == code, "expected error \(code), got \(error.jsonRPCCode)")
+        } catch {
+            fail("unexpected error: \(error)")
+        }
+    }
+
+    private static func checkValue(_ value: SpaceAPIJSONValue?, _ message: String) throws -> SpaceAPIJSONValue {
+        guard let value else { throw TestFailure(message) }
+        return value
+    }
+
+    private static func checkJSONObject(_ value: Any?) throws -> [String: Any] {
+        guard let object = value as? [String: Any] else { throw TestFailure("expected JSON object") }
+        return object
+    }
+
+    private static func jsonString(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func check(_ condition: Bool, _ message: String) {
+        if !condition { fail(message) }
+    }
+
+    private static func fail(_ message: String) -> Never {
+        fatalError(message)
+    }
+
+    private struct TestFailure: Error {
+        let message: String
+
+        init(_ message: String) {
+            self.message = message
+        }
+    }
+}

--- a/Tests/SpaceAPIContractTests.swift
+++ b/Tests/SpaceAPIContractTests.swift
@@ -40,6 +40,11 @@ struct SpaceAPIContractTests {
             operation: SpaceAPIJSONRPCCodec.decodeRequest
         )
         expectError(
+            -32602,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"getAPIInfo\",\"params\":null}",
+            operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+        expectError(
             -32006,
             payload: String(repeating: "x", count: DesktopRenamerAPIContract.maxPayloadBytes + 1),
             operation: SpaceAPIJSONRPCCodec.decodeRequest
@@ -112,6 +117,11 @@ struct SpaceAPIContractTests {
         check(decodedError.error?.code == -32602, "error code round trip")
         let errorData = try decodedError.error?.data?.decode(SpaceAPIErrorData.self)
         check(errorData?.parameter == "spaceID", "error metadata round trip")
+
+        let nullResult = try SpaceAPIJSONRPCCodec.decodeResponse(
+            "{\"jsonrpc\":\"2.0\",\"id\":\"null-result\",\"result\":null}"
+        )
+        check(nullResult.result == .null, "nullable JSON-RPC result is preserved")
 
         expectError(
             -32600,

--- a/Tests/SpaceAPIContractTests.swift
+++ b/Tests/SpaceAPIContractTests.swift
@@ -3,11 +3,41 @@ import Foundation
 @main
 struct SpaceAPIContractTests {
     static func main() throws {
+        try testMethodDefinitions()
+        try testParameterValidation()
         try testRequestRoundTripAndValidation()
         try testResponseRoundTripAndUnknownFields()
+        try testNullableFieldBackwardCompatibility()
         try testEventRoundTrip()
         try testLegacyFixtures()
         print("SpaceAPI contract tests passed")
+    }
+
+    private static func testMethodDefinitions() throws {
+        let definitions = DesktopRenamerAPIContract.methodDefinitions
+        let names = definitions.map(\.name)
+        check(Set(names).count == names.count, "method names are unique")
+        check(names == DesktopRenamerAPIContract.supportedMethods, "supported methods follow definitions")
+
+        for definition in definitions {
+            check(
+                definition.requiredParameters.isSubset(of: Set(definition.parameters.keys)),
+                "required parameters are declared for \(definition.name)"
+            )
+        }
+
+        let booleanMethods = definitions.filter { $0.resultKind == .boolean }.map(\.name)
+        check(
+            booleanMethods == [
+                "toggleMenubar",
+                "toggleLauncher",
+                "toggleLabels",
+                "toggleActiveLabel",
+                "togglePreviewLabel",
+                "toggleDesktopVisibility"
+            ],
+            "toggle methods expose Boolean results"
+        )
     }
 
     private static func testRequestRoundTripAndValidation() throws {
@@ -22,32 +52,102 @@ struct SpaceAPIContractTests {
         let payload = try SpaceAPIJSONRPCCodec.encode(request)
         check(try SpaceAPIJSONRPCCodec.decodeRequest(payload) == request, "request round trip")
 
-        expectError(-32700, payload: "{", operation: SpaceAPIJSONRPCCodec.decodeRequest)
-        expectError(-32600, payload: "[]", operation: SpaceAPIJSONRPCCodec.decodeRequest)
+        expectError(SpaceAPIJSONRPCCode.parseError, payload: "{", operation: SpaceAPIJSONRPCCodec.decodeRequest)
+        expectError(SpaceAPIJSONRPCCode.invalidRequest, payload: "[]", operation: SpaceAPIJSONRPCCodec.decodeRequest)
         expectError(
-            -32600,
+            SpaceAPIJSONRPCCode.invalidRequest,
             payload: "{\"jsonrpc\":\"1.0\",\"id\":\"1\",\"method\":\"getAPIInfo\"}",
             operation: SpaceAPIJSONRPCCodec.decodeRequest
         )
         expectError(
-            -32600,
+            SpaceAPIJSONRPCCode.invalidRequest,
             payload: "{\"jsonrpc\":\"2.0\",\"method\":\"getAPIInfo\"}",
             operation: SpaceAPIJSONRPCCodec.decodeRequest
         )
         expectError(
-            -32602,
+            SpaceAPIJSONRPCCode.invalidParams,
             payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"getAPIInfo\",\"params\":[]}",
             operation: SpaceAPIJSONRPCCodec.decodeRequest
         )
         expectError(
-            -32602,
+            SpaceAPIJSONRPCCode.invalidParams,
             payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"getAPIInfo\",\"params\":null}",
             operation: SpaceAPIJSONRPCCodec.decodeRequest
         )
         expectError(
-            -32006,
+            SpaceAPIJSONRPCCode.payloadTooLarge,
             payload: String(repeating: "x", count: DesktopRenamerAPIContract.maxPayloadBytes + 1),
             operation: SpaceAPIJSONRPCCodec.decodeRequest
+        )
+
+        let oversizedRequest = SpaceAPIJSONRPCRequest(
+            id: "large-request",
+            method: "renameCurrentSpace",
+            params: ["name": .string(String(repeating: "x", count: DesktopRenamerAPIContract.maxPayloadBytes))]
+        )
+        do {
+            _ = try SpaceAPIJSONRPCCodec.encode(oversizedRequest)
+            fail("expected oversized request to be rejected")
+        } catch let error as SpaceAPIContractError {
+            check(error.jsonRPCCode == SpaceAPIJSONRPCCode.payloadTooLarge, "encoded requests enforce payload limit")
+        }
+    }
+
+    private static func testParameterValidation() throws {
+        let normalized = try SpaceAPIArgumentValidator.stringArguments(
+            from: .object([
+                "spaceID": .string("space-4"),
+                "direction": .string("UP")
+            ]),
+            method: "rearrangeSpace"
+        )
+        check(normalized["direction"] == "up", "direction parameters are normalized")
+
+        let numeric = try SpaceAPIArgumentValidator.stringArguments(
+            from: .object([
+                "windowID": .number(123),
+                "pid": .number(456),
+                "fromSpaceID": .string("4"),
+                "targetSpaceID": .string("5")
+            ]),
+            method: "moveSpecificWindow"
+        )
+        check(numeric["windowID"] == "123" && numeric["pid"] == "456", "numeric IDs are normalized")
+
+        let withoutOptionalPID = try SpaceAPIArgumentValidator.stringArguments(
+            from: .object([
+                "windowID": .string("123"),
+                "fromSpaceID": .string("4"),
+                "targetSpaceID": .string("5")
+            ]),
+            method: "moveSpecificWindow"
+        )
+        check(withoutOptionalPID["pid"] == nil, "optional process IDs can be omitted")
+
+        expectParameterError(
+            parameter: "spaceID",
+            params: .object([:]),
+            method: "switchToSpace"
+        )
+        expectParameterError(
+            parameter: "unexpected",
+            params: .object(["unexpected": .string("value")]),
+            method: "getAPIInfo"
+        )
+        expectParameterError(
+            parameter: "direction",
+            params: .object(["spaceID": .string("4"), "direction": .string("sideways")]),
+            method: "rearrangeSpace"
+        )
+        expectParameterError(
+            parameter: "pid",
+            params: .object(["windowID": .number(123), "pid": .number(0)]),
+            method: "focusWindow"
+        )
+        expectParameterError(
+            parameter: "params",
+            params: .array([]),
+            method: "getAPIInfo"
         )
     }
 
@@ -95,6 +195,20 @@ struct SpaceAPIContractTests {
             .decode(SpaceAPISnapshot.self)
         check(decodedSnapshot == snapshot, "snapshot with nullable and delimiter fields")
 
+        let encodedResponse = try checkJSONObject(
+            JSONSerialization.jsonObject(with: Data(payload.utf8), options: [.fragmentsAllowed])
+        )
+        let encodedResult = try checkJSONObject(encodedResponse["result"])
+        let encodedSnapshot = try checkJSONObject(encodedResult["snapshot"])
+        let encodedSpace = try checkJSONObject(try checkArray(encodedSnapshot["spaces"]).first)
+        check(encodedSpace["appName"] is NSNull, "nullable space appName is encoded as null")
+        check(encodedSpace["appPath"] is NSNull, "nullable space appPath is encoded as null")
+
+        let encodedWindows = try checkArray(encodedResult["windows"])
+        let encodedWindow = try checkJSONObject(encodedWindows.first)
+        check(encodedWindow["appPath"] is NSNull, "nullable window appPath is encoded as null")
+        check(encodedWindow["title"] is NSNull, "nullable window title is encoded as null")
+
         let payloadObject = try JSONSerialization.jsonObject(with: Data(payload.utf8), options: [.fragmentsAllowed])
         var jsonObject = try checkJSONObject(payloadObject)
         var resultObject = try checkJSONObject(jsonObject["result"])
@@ -108,13 +222,13 @@ struct SpaceAPIContractTests {
 
         let error = SpaceAPIJSONRPCCodec.errorResponse(
             id: "request-3",
-            code: -32602,
+            code: SpaceAPIJSONRPCCode.invalidParams,
             message: "Invalid parameter.",
             data: SpaceAPIErrorData(parameter: "spaceID", expected: "string", command: "switchToSpace")
         )
         let errorPayload = try SpaceAPIJSONRPCCodec.encode(error)
         let decodedError = try SpaceAPIJSONRPCCodec.decodeResponse(errorPayload)
-        check(decodedError.error?.code == -32602, "error code round trip")
+        check(decodedError.error?.code == SpaceAPIJSONRPCCode.invalidParams, "error code round trip")
         let errorData = try decodedError.error?.data?.decode(SpaceAPIErrorData.self)
         check(errorData?.parameter == "spaceID", "error metadata round trip")
 
@@ -123,16 +237,57 @@ struct SpaceAPIContractTests {
         )
         check(nullResult.result == .null, "nullable JSON-RPC result is preserved")
 
+        let nullIDError = SpaceAPIJSONRPCCodec.errorResponse(
+            id: nil,
+            code: SpaceAPIJSONRPCCode.invalidRequest,
+            message: "Malformed request."
+        )
+        let nullIDPayload = try SpaceAPIJSONRPCCodec.encode(nullIDError)
+        let nullIDObject = try checkJSONObject(
+            JSONSerialization.jsonObject(with: Data(nullIDPayload.utf8), options: [.fragmentsAllowed])
+        )
+        check(nullIDObject["id"] is NSNull, "unknown response IDs are encoded as explicit null")
+        check(try SpaceAPIJSONRPCCodec.decodeResponse(nullIDPayload).id == nil, "null response IDs decode as nil")
+
         expectError(
-            -32600,
+            SpaceAPIJSONRPCCode.invalidRequest,
             payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{},\"error\":{\"code\":-1,\"message\":\"failed\"}}",
             operation: SpaceAPIJSONRPCCodec.decodeResponse
         )
         expectError(
-            -32600,
+            SpaceAPIJSONRPCCode.invalidRequest,
             payload: "{\"jsonrpc\":\"2.0\",\"id\":\"1\"}",
             operation: SpaceAPIJSONRPCCodec.decodeResponse
         )
+        expectError(
+            SpaceAPIJSONRPCCode.invalidRequest,
+            payload: "{\"jsonrpc\":\"2.0\",\"result\":{}}",
+            operation: SpaceAPIJSONRPCCodec.decodeResponse
+        )
+        expectError(
+            SpaceAPIJSONRPCCode.invalidRequest,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":null,\"result\":{}}",
+            operation: SpaceAPIJSONRPCCodec.decodeResponse
+        )
+
+        let successfulResponseWithNullID = SpaceAPIJSONRPCResponse(id: nil, result: .object([:]))
+        do {
+            _ = try SpaceAPIJSONRPCCodec.encode(successfulResponseWithNullID)
+            fail("expected successful response with null ID to be rejected")
+        } catch let error as SpaceAPIContractError {
+            check(error.jsonRPCCode == SpaceAPIJSONRPCCode.invalidRequest, "null result ID uses invalid request code")
+        }
+
+        let oversizedResponse = SpaceAPIJSONRPCResponse(
+            id: "large-response",
+            result: .string(String(repeating: "x", count: DesktopRenamerAPIContract.maxPayloadBytes))
+        )
+        do {
+            _ = try SpaceAPIJSONRPCCodec.encode(oversizedResponse)
+            fail("expected oversized response to be rejected")
+        } catch let error as SpaceAPIContractError {
+            check(error.jsonRPCCode == SpaceAPIJSONRPCCode.payloadTooLarge, "encoded responses enforce payload limit")
+        }
     }
 
     private static func testEventRoundTrip() throws {
@@ -147,10 +302,49 @@ struct SpaceAPIContractTests {
         check(try SpaceAPIJSONRPCCodec.decodeEvent(payload) == event, "event round trip")
 
         expectError(
-            -32602,
+            SpaceAPIJSONRPCCode.invalidParams,
             payload: "{\"jsonrpc\":\"2.0\",\"method\":\"stateChanged\",\"params\":[]}",
             operation: SpaceAPIJSONRPCCodec.decodeEvent
         )
+        expectError(
+            SpaceAPIJSONRPCCode.invalidRequest,
+            payload: "{\"jsonrpc\":\"2.0\",\"id\":\"event-1\",\"method\":\"stateChanged\",\"params\":{}}",
+            operation: SpaceAPIJSONRPCCodec.decodeEvent
+        )
+        expectError(
+            SpaceAPIJSONRPCCode.invalidRequest,
+            payload: "{\"jsonrpc\":\"2.0\",\"method\":\"\(String(repeating: "x", count: 129))\",\"params\":{}}",
+            operation: SpaceAPIJSONRPCCodec.decodeEvent
+        )
+    }
+
+    private static func testNullableFieldBackwardCompatibility() throws {
+        let spacePayload = """
+        {
+          "id": "space-1",
+          "name": "Writing",
+          "displayID": "display-1",
+          "displayName": "Built-in Display",
+          "number": 1,
+          "isFullscreen": false
+        }
+        """
+        let space = try JSONDecoder().decode(SpaceAPISpace.self, from: Data(spacePayload.utf8))
+        check(space.appName == nil && space.appPath == nil && space.globalShortcutNumber == nil,
+              "missing nullable space fields decode as nil")
+
+        let windowPayload = """
+        {
+          "id": 123,
+          "pid": 456,
+          "ownerName": "Example",
+          "spaceID": "space-1",
+          "isMinimized": false,
+          "isHidden": false
+        }
+        """
+        let window = try JSONDecoder().decode(SpaceAPIWindow.self, from: Data(windowPayload.utf8))
+        check(window.appPath == nil && window.title == nil, "missing nullable window fields decode as nil")
     }
 
     private static func testLegacyFixtures() throws {
@@ -197,6 +391,28 @@ struct SpaceAPIContractTests {
         }
     }
 
+    private static func expectParameterError(
+        parameter: String,
+        params: SpaceAPIJSONValue?,
+        method: String
+    ) {
+        do {
+            _ = try SpaceAPIArgumentValidator.stringArguments(from: params, method: method)
+            fail("expected parameter error for \(parameter)")
+        } catch let error as SpaceAPIContractError {
+            check(error.jsonRPCCode == SpaceAPIJSONRPCCode.invalidParams, "expected invalid parameter code")
+            guard case .invalidParamsWithData(_, let data) = error else {
+                fail("expected parameter metadata for \(parameter)")
+            }
+            check(
+                data.parameter == parameter && data.command == method,
+                "parameter metadata for \(parameter): \(String(describing: data.parameter)) / \(String(describing: data.command))"
+            )
+        } catch {
+            fail("unexpected parameter error: \(error)")
+        }
+    }
+
     private static func checkValue(_ value: SpaceAPIJSONValue?, _ message: String) throws -> SpaceAPIJSONValue {
         guard let value else { throw TestFailure(message) }
         return value
@@ -205,6 +421,11 @@ struct SpaceAPIContractTests {
     private static func checkJSONObject(_ value: Any?) throws -> [String: Any] {
         guard let object = value as? [String: Any] else { throw TestFailure("expected JSON object") }
         return object
+    }
+
+    private static func checkArray(_ value: Any?) throws -> [Any] {
+        guard let array = value as? [Any] else { throw TestFailure("expected JSON array") }
+        return array
     }
 
     private static func jsonString(_ object: [String: Any]) throws -> String {


### PR DESCRIPTION
Adopt a new JSON RPC 2.0 format SpaceAPI. AppleScript format is mostly untouched.

Miscellaneous fixes regarding the labels and the switch overrides are also incorporated into this PR.